### PR TITLE
[codex] align loginId auth with final spec

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,9 @@ java -jar out/study-room-cli.jar
 
 ## 기본 admin 계정
 
-- userId: `admin`
+- userId: `user001`
+- loginId: `user001`
+- userName: `admin`
 - password: `admin1234`
 
 ## 데이터 파일 형식
@@ -32,7 +34,7 @@ java -jar out/study-room-cli.jar
 기본 데이터 폴더는 프로젝트 루트의 `data/` 입니다.
 
 - `data/users.txt`
-  - `USER|userId|password|userName|role`
+  - `USER|userId|loginId|password|userName|role`
 - `data/rooms.txt`
   - `ROOM|roomId|roomName|maxCapacity|roomStatus`
 - `data/reservations.txt`
@@ -50,8 +52,9 @@ java -jar out/study-room-cli.jar
 ## 주요 기능
 
 - 비로그인: 회원가입, 로그인, 종료
+  - 회원가입 시 `userId` 자동 발급
+  - 로그인은 `loginId + password`
 - member:
-  - 현재 가상 시각 조회
   - 현재 가상 시각 변경
   - 예약 가능 스터디룸 조회
   - 예약 신청
@@ -59,7 +62,7 @@ java -jar out/study-room-cli.jar
   - 나의 예약 조회
   - 체크인
 - admin:
-  - 현재 가상 시각 조회/변경
+  - 현재 가상 시각 변경
   - 전체 예약 정보 조회
   - 예약 조정(방 이동)
   - 룸 컨디션 관리

--- a/data/users.txt
+++ b/data/users.txt
@@ -1,1 +1,3 @@
-USER|admin|admin1234|관리자|admin
+USER|user001|user001|admin1234|admin|admin
+USER|user101|user101|12345|bonsu|member
+USER|user102|user102|1234|minseo|member

--- a/src/CliApp.java
+++ b/src/CliApp.java
@@ -15,7 +15,8 @@ import java.util.Set;
 import java.util.regex.Pattern;
 
 final class CliApp {
-    private static final Pattern USER_ID_PATTERN = Pattern.compile("^[A-Za-z][A-Za-z0-9_]{3,19}$");
+    private static final Pattern LOGIN_ID_PATTERN = Pattern.compile("^[A-Za-z][A-Za-z0-9_]{3,19}$");
+    private static final Pattern USER_NAME_PATTERN = Pattern.compile("^[A-Za-z][A-Za-z0-9_]{3,19}$");
     private static final Pattern ROOM_ID_PATTERN = Pattern.compile("^R[0-9]{3}$");
     private static final Pattern RESERVATION_ID_PATTERN = Pattern.compile("^rv[0-9]{4}$");
 
@@ -79,82 +80,99 @@ final class CliApp {
         System.out.println("0. 종료");
 
         int menu = promptMenuChoice(Set.of(1, 2, 0));
-        if (menu == 1) {
-            handleSignup();
-        } else if (menu == 2) {
-            handleLogin();
-        } else {
-            System.out.println("프로그램을 종료합니다.");
-            throw new ExitProgramException();
+        try {
+            if (menu == 1) {
+                handleSignup();
+            } else if (menu == 2) {
+                handleLogin();
+            } else {
+                System.out.println("프로그램을 종료합니다.");
+                throw new ExitProgramException();
+            }
+        } catch (ActionAbortedException ignored) {
         }
     }
 
     private void memberMenu() throws AppDataException {
+        SystemData data = loadAndSync();
         System.out.println();
         System.out.println("[member 메뉴]");
-        System.out.println("1. 현재 가상 시각 조회");
-        System.out.println("2. 현재 가상 시각 변경");
-        System.out.println("3. 예약 가능 스터디룸 조회");
-        System.out.println("4. 예약 신청");
-        System.out.println("5. 예약 취소");
-        System.out.println("6. 나의 예약 조회");
-        System.out.println("7. 체크인");
+        System.out.println("현재 가상 시각: " + TimeFormats.formatDateTime(data.currentTime));
+        System.out.println("1. 현재 가상 시각 변경");
+        System.out.println("2. 예약 가능 스터디룸 조회");
+        System.out.println("3. 예약 신청");
+        System.out.println("4. 예약 취소");
+        System.out.println("5. 나의 예약 조회");
+        System.out.println("6. 체크인");
         System.out.println("0. 로그아웃");
 
-        int menu = promptMenuChoice(Set.of(0, 1, 2, 3, 4, 5, 6, 7));
-        switch (menu) {
-            case 1 -> handleViewCurrentTime();
-            case 2 -> handleChangeCurrentTime();
-            case 3 -> handleSearchAvailableRooms();
-            case 4 -> handleCreateReservation();
-            case 5 -> handleCancelReservation();
-            case 6 -> handleMyReservations();
-            case 7 -> handleCheckIn();
-            case 0 -> handleLogout();
-            default -> throw new IllegalStateException();
+        int menu = promptMenuChoice(Set.of(0, 1, 2, 3, 4, 5, 6));
+        try {
+            switch (menu) {
+                case 1 -> handleChangeCurrentTime();
+                case 2 -> handleSearchAvailableRooms();
+                case 3 -> handleCreateReservation();
+                case 4 -> handleCancelReservation();
+                case 5 -> handleMyReservations();
+                case 6 -> handleCheckIn();
+                case 0 -> handleLogout();
+                default -> throw new IllegalStateException();
+            }
+        } catch (ActionAbortedException ignored) {
         }
     }
 
     private void adminMenu() throws AppDataException {
+        SystemData data = loadAndSync();
         System.out.println();
         System.out.println("[admin 메뉴]");
-        System.out.println("1. 현재 가상 시각 조회");
-        System.out.println("2. 현재 가상 시각 변경");
-        System.out.println("3. 전체 예약 정보 조회");
-        System.out.println("4. 예약 조정(방 이동)");
-        System.out.println("5. 룸 컨디션 관리");
+        System.out.println("현재 가상 시각: " + TimeFormats.formatDateTime(data.currentTime));
+        System.out.println("1. 현재 가상 시각 변경");
+        System.out.println("2. 전체 예약 정보 조회");
+        System.out.println("3. 예약 조정(방 이동)");
+        System.out.println("4. 룸 컨디션 관리");
         System.out.println("0. 로그아웃");
 
-        int menu = promptMenuChoice(Set.of(1, 2, 3, 4, 5, 0));
-        switch (menu) {
-            case 1 -> handleViewCurrentTime();
-            case 2 -> handleChangeCurrentTime();
-            case 3 -> handleAllReservations();
-            case 4 -> handleAdjustReservationRoom();
-            case 5 -> handleRoomConditionMenu();
-            case 0 -> handleLogout();
-            default -> throw new IllegalStateException();
+        int menu = promptMenuChoice(Set.of(1, 2, 3, 4, 0));
+        try {
+            switch (menu) {
+                case 1 -> handleChangeCurrentTime();
+                case 2 -> handleAllReservations();
+                case 3 -> handleAdjustReservationRoom();
+                case 4 -> handleRoomConditionMenu();
+                case 0 -> handleLogout();
+                default -> throw new IllegalStateException();
+            }
+        } catch (ActionAbortedException ignored) {
         }
     }
 
     private void handleSignup() throws AppDataException {
         SystemData data = store.loadAll();
-        String userId = promptNewUserId(data);
+        System.out.println("[회원가입]");
+        String loginId = promptLoginId("로그인 ID 입력: ");
         String password = promptPassword();
-        String userName = promptDisplayName();
+        String userName = promptNewUserName();
+        if (data.findUserByLoginId(loginId) != null) {
+            System.out.println("오류: 이미 사용 중인 로그인 ID입니다.");
+            return;
+        }
+        String userId = data.nextUserId();
 
-        data.users.put(userId, new User(userId, password, userName, Role.MEMBER, 0));
+        data.users.put(userId, new User(userId, loginId, password, userName, Role.MEMBER, 0));
         store.saveAll(data);
         System.out.println("회원가입이 완료되었습니다.");
+        System.out.println("발급된 사용자 ID: " + userId);
     }
 
     private void handleLogin() throws AppDataException {
         SystemData loaded = store.loadAll();
-        String userId = promptLine("사용자 ID: ").trim();
-        String password = promptLine("비밀번호: ").trim();
-        User user = loaded.users.get(userId);
+        System.out.println("[로그인]");
+        String loginId = promptLoginId("로그인 ID: ");
+        String password = promptPassword("비밀번호: ");
+        User user = loaded.findUserByLoginId(loginId);
         if (user == null) {
-            System.out.println("오류: 존재하지 않는 사용자 ID입니다.");
+            System.out.println("오류: 존재하지 않는 로그인 ID입니다.");
             return;
         }
         if (!user.password.equals(password)) {
@@ -163,7 +181,7 @@ final class CliApp {
         }
 
         SystemData synced = loadAndSync();
-        User syncedUser = synced.users.get(userId);
+        User syncedUser = synced.users.get(user.userId);
         if (syncedUser == null) {
             System.out.println("오류: 로그인할 수 없는 계정입니다.");
             return;
@@ -171,7 +189,7 @@ final class CliApp {
 
         loggedInUserId = syncedUser.userId;
         loggedInRole = syncedUser.role;
-        System.out.println("로그인 성공: " + syncedUser.userName + " (" + syncedUser.role.fileValue() + ")");
+        System.out.println("로그인 성공: " + syncedUser.userName + " (role: " + syncedUser.role.fileValue() + ")");
     }
 
     private void handleLogout() {
@@ -188,6 +206,8 @@ final class CliApp {
     private void handleSearchAvailableRooms() throws AppDataException {
         requireRole(Role.MEMBER);
         SystemData data = loadAndSync();
+        System.out.println("[예약 가능 스터디룸 조회]");
+        System.out.println("현재 가상 시각: " + TimeFormats.formatDateTime(data.currentTime));
         LocalDate date = promptDate("날짜 입력(yyyy-MM-dd): ");
         LocalTime start = promptTime("시작 시각 입력(HH:mm): ");
         LocalTime end = promptTime("종료 시각 입력(HH:mm): ");
@@ -219,12 +239,16 @@ final class CliApp {
         }
         if (count == 0) {
             System.out.println("조회 결과가 없습니다.");
+            return;
         }
+        System.out.println("조회가 끝났습니다.");
     }
 
     private void handleCreateReservation() throws AppDataException {
         requireRole(Role.MEMBER);
         SystemData data = loadAndSync();
+        System.out.println("[예약 신청]");
+        System.out.println("현재 가상 시각: " + TimeFormats.formatDateTime(data.currentTime));
 
         LocalDate date = promptDate("날짜 입력(yyyy-MM-dd): ");
         LocalTime start = promptTime("시작 시각 입력(HH:mm): ");
@@ -288,6 +312,8 @@ final class CliApp {
     private void handleCancelReservation() throws AppDataException {
         requireRole(Role.MEMBER);
         SystemData data = loadAndSync();
+        System.out.println("[예약 취소]");
+        System.out.println("현재 가상 시각: " + TimeFormats.formatDateTime(data.currentTime));
         String reservationId = promptReservationId("취소할 예약번호 입력: ");
 
         Reservation reservation = data.reservations.get(reservationId);
@@ -316,6 +342,8 @@ final class CliApp {
     private void handleMyReservations() throws AppDataException {
         requireRole(Role.MEMBER);
         SystemData data = loadAndSync();
+        System.out.println("[나의 예약 조회]");
+        System.out.println("현재 가상 시각: " + TimeFormats.formatDateTime(data.currentTime));
         List<Reservation> mine = new ArrayList<>();
         for (Reservation reservation : data.sortedReservations()) {
             if (reservation.userId.equals(loggedInUserId)) {
@@ -341,11 +369,14 @@ final class CliApp {
                     reservation.partySize,
                     reservation.status.name());
         }
+        System.out.println("조회가 끝났습니다.");
     }
 
     private void handleCheckIn() throws AppDataException {
         requireRole(Role.MEMBER);
         SystemData data = loadAndSync();
+        System.out.println("[체크인]");
+        System.out.println("현재 가상 시각: " + TimeFormats.formatDateTime(data.currentTime));
         String reservationId = promptReservationId("체크인할 예약번호 입력: ");
 
         Reservation reservation = data.reservations.get(reservationId);
@@ -389,6 +420,8 @@ final class CliApp {
     private void handleChangeCurrentTime() throws AppDataException {
         requireLoggedIn();
         SystemData data = loadAndSync();
+        System.out.println("[현재 가상 시각 변경]");
+        System.out.println("현재 가상 시각: " + TimeFormats.formatDateTime(data.currentTime));
         LocalDateTime before = data.currentTime;
         LocalDateTime next = promptDateTime("새 현재 시각 입력(yyyy-MM-dd HH:mm): ");
         System.out.println("기존 시각: " + TimeFormats.formatDateTime(before));
@@ -408,17 +441,22 @@ final class CliApp {
     private void handleAllReservations() throws AppDataException {
         requireRole(Role.ADMIN);
         SystemData data = loadAndSync();
+        System.out.println("[전체 예약 정보 조회]");
+        System.out.println("현재 가상 시각: " + TimeFormats.formatDateTime(data.currentTime));
         if (data.reservations.isEmpty()) {
             System.out.println("예약 데이터가 없습니다.");
             return;
         }
 
-        System.out.printf("%-8s %-10s %-6s %-10s %-5s %-5s %-4s %-12s %-16s%n",
-                "reservation", "userId", "room", "date", "start", "end", "인원", "status", "checkedInAt");
+        System.out.printf("%-8s %-10s %-10s %-6s %-10s %-5s %-5s %-4s %-12s %-16s%n",
+                "resvId", "userId", "userName", "room", "date", "start", "end", "인원", "status", "checkedInAt");
         for (Reservation reservation : data.sortedReservations()) {
-            System.out.printf("%-8s %-10s %-6s %-10s %-5s %-5s %-4d %-12s %-16s%n",
+            User user = data.users.get(reservation.userId);
+            String userName = user == null ? reservation.userId : user.userName;
+            System.out.printf("%-8s %-10s %-10s %-6s %-10s %-5s %-5s %-4d %-12s %-16s%n",
                     reservation.reservationId,
                     reservation.userId,
+                    cut(userName, 10),
                     reservation.roomId,
                     TimeFormats.formatDate(reservation.date),
                     TimeFormats.formatTime(reservation.startTime),
@@ -427,11 +465,14 @@ final class CliApp {
                     reservation.status.name(),
                     reservation.checkedInAtText());
         }
+        System.out.println("조회가 끝났습니다.");
     }
 
     private void handleAdjustReservationRoom() throws AppDataException {
         requireRole(Role.ADMIN);
         SystemData data = loadAndSync();
+        System.out.println("[예약 조정(방 이동)]");
+        System.out.println("현재 가상 시각: " + TimeFormats.formatDateTime(data.currentTime));
 
         String reservationId = promptReservationId("조정할 예약번호 입력: ");
         String targetRoomId = promptRoomId("대상 룸 ID 입력: ");
@@ -452,16 +493,20 @@ final class CliApp {
             return;
         }
 
+        String beforeRecord = reservation.toRecord();
         reservation.roomId = targetRoomId;
         store.saveAll(data);
+        printRecordChange("예약", beforeRecord, reservation.toRecord());
         System.out.println("예약 조정이 완료되었습니다.");
     }
 
     private void handleRoomConditionMenu() throws AppDataException {
         requireRole(Role.ADMIN);
         while (true) {
+            SystemData data = loadAndSync();
             System.out.println();
             System.out.println("[룸 컨디션 관리]");
+            System.out.println("현재 가상 시각: " + TimeFormats.formatDateTime(data.currentTime));
             System.out.println("1. 전체 룸 조회");
             System.out.println("2. 룸 최대 수용 인원 변경");
             System.out.println("3. 룸 임시 휴업");
@@ -484,15 +529,19 @@ final class CliApp {
     }
 
     private void handleRoomList() throws AppDataException {
-        SystemData data = store.loadAll();
+        SystemData data = loadAndSync();
+        System.out.println("[전체 룸 조회]");
         printRoomHeader();
         for (Room room : data.sortedRooms()) {
             printRoomRow(room);
         }
+        System.out.println("조회가 끝났습니다.");
     }
 
     private void handleChangeRoomCapacity() throws AppDataException {
         SystemData data = loadAndSync();
+        System.out.println("[최대 수용 인원 변경]");
+        System.out.println("현재 가상 시각: " + TimeFormats.formatDateTime(data.currentTime));
         String roomId = promptRoomId("룸 ID 입력: ");
         int newCapacity = promptPositiveInt("새 최대 수용 인원 입력: ");
 
@@ -502,29 +551,34 @@ final class CliApp {
             return;
         }
 
-        List<Reservation> impacted = findFutureReservedWithTooManyPeople(data, roomId, newCapacity);
-        int original = room.maxCapacity;
-        if (!impacted.isEmpty()) {
-            System.out.println("영향 예약이 있어 처리 흐름을 시작합니다.");
-            boolean success = processImpactedReservations(data, impacted);
-            if (!success) {
-                room.maxCapacity = original;
-                System.out.println("룸 컨디션 변경을 취소하여 원상복구했습니다.");
-                return;
-            }
-        }
         if (hasActiveReservationOverCapacity(data, roomId, newCapacity)) {
-            System.out.println("오류: 활성 예약 인원이 새 수용 인원을 초과하여 변경할 수 없습니다.");
+            System.out.println("오류: 현재 CHECKED_IN 예약 인원이 새 최대 수용 인원을 초과하여 변경할 수 없습니다.");
             return;
         }
 
+        List<Reservation> impacted = findFutureReservedWithTooManyPeople(data, roomId, newCapacity);
+        if (!impacted.isEmpty()) {
+            System.out.println("현재 CHECKED_IN 예약 인원 검사 통과");
+            System.out.println("영향 예약이 있어 처리 흐름을 시작합니다.");
+            boolean success = processImpactedReservations(data, impacted);
+            if (!success) {
+                System.out.println("룸 컨디션 변경을 취소하여 원상복구했습니다.");
+                return;
+            }
+            System.out.println("영향 예약 처리가 완료되었습니다.");
+        }
+
+        String beforeRoomRecord = room.toRecord();
         room.maxCapacity = newCapacity;
         store.saveAll(data);
+        printRecordChange("ROOM", beforeRoomRecord, room.toRecord());
         System.out.println("룸 최대 수용 인원이 변경되었습니다.");
     }
 
     private void handleCloseRoom() throws AppDataException {
         SystemData data = loadAndSync();
+        System.out.println("[룸 임시 휴업]");
+        System.out.println("현재 가상 시각: " + TimeFormats.formatDateTime(data.currentTime));
         String roomId = promptRoomId("휴업할 룸 ID 입력: ");
         Room room = data.rooms.get(roomId);
         if (room == null) {
@@ -555,21 +609,27 @@ final class CliApp {
             return;
         }
 
+        String beforeRoomRecord = room.toRecord();
         room.roomStatus = RoomStatus.CLOSED;
         store.saveAll(data);
-        System.out.println("룸이 임시 휴업 상태(CLOSED)로 변경되었습니다.");
+        printRecordChange("ROOM", beforeRoomRecord, room.toRecord());
+        System.out.println("룸이 임시 휴업 처리되었습니다.");
     }
 
     private void handleOpenRoom() throws AppDataException {
         SystemData data = loadAndSync();
+        System.out.println("[룸 운영 재개]");
+        System.out.println("현재 가상 시각: " + TimeFormats.formatDateTime(data.currentTime));
         String roomId = promptRoomId("운영 재개할 룸 ID 입력: ");
         Room room = data.rooms.get(roomId);
         if (room == null) {
             System.out.println("오류: 존재하지 않는 룸 ID입니다.");
             return;
         }
+        String beforeRoomRecord = room.toRecord();
         room.roomStatus = RoomStatus.OPEN;
         store.saveAll(data);
+        printRecordChange("ROOM", beforeRoomRecord, room.toRecord());
         System.out.println("룸 운영이 재개되었습니다.");
     }
 
@@ -582,14 +642,8 @@ final class CliApp {
         for (Reservation reservation : impacted) {
             while (true) {
                 Reservation current = data.reservations.getOrDefault(reservation.reservationId, reservation);
-                System.out.printf("영향 예약: %s | user=%s | room=%s | %s %s-%s | 인원=%d%n",
-                        current.reservationId,
-                        current.userId,
-                        current.roomId,
-                        TimeFormats.formatDate(current.date),
-                        TimeFormats.formatTime(current.startTime),
-                        TimeFormats.formatTime(current.endTime),
-                        current.partySize);
+                System.out.println("영향 예약 레코드:");
+                System.out.println(current.toRecord());
                 System.out.println("1) 다른 룸으로 이동");
                 System.out.println("2) 해당 예약 취소");
                 System.out.println("0) 이번 룸 컨디션 변경 전체 취소");
@@ -610,8 +664,10 @@ final class CliApp {
                     System.out.println("오류: " + moveError);
                     continue;
                 }
+                String beforeRecord = current.toRecord();
                 current.roomId = targetRoomId;
                 data.reservations.put(current.reservationId, current);
+                printRecordChange("RESV", beforeRecord, current.toRecord());
                 break;
             }
         }
@@ -665,7 +721,7 @@ final class CliApp {
             if (!reservation.roomId.equals(roomId)) {
                 continue;
             }
-            if (!reservation.activeForOverlap()) {
+            if (reservation.status != ReservationStatus.CHECKED_IN) {
                 continue;
             }
             if (reservation.partySize > newCapacity) {
@@ -684,7 +740,7 @@ final class CliApp {
             return "현재 룸과 다른 룸으로만 이동할 수 있습니다.";
         }
         if (target.roomStatus != RoomStatus.OPEN) {
-            return "대상 룸이 휴업 상태입니다.";
+            return "대상 룸이 OPEN 상태가 아니어서 이동할 수 없습니다.";
         }
         if (target.maxCapacity < reservation.partySize) {
             return "대상 룸의 수용 인원이 부족합니다.";
@@ -818,7 +874,11 @@ final class CliApp {
 
     private int promptMenuChoice(Set<Integer> allowed) {
         while (true) {
-            String input = promptLine("메뉴 선택: ").trim();
+            String input = promptLine("메뉴 선택: ");
+            if (!input.equals(input.trim())) {
+                System.out.println("오류: 메뉴 선택 앞뒤에 공백을 넣을 수 없습니다.");
+                continue;
+            }
             if (!input.matches("^[0-9]+$")) {
                 System.out.println("오류: 메뉴 번호는 숫자로 입력해야 합니다.");
                 continue;
@@ -838,124 +898,98 @@ final class CliApp {
         }
     }
 
-    private String promptNewUserId(SystemData data) {
-        while (true) {
-            String userId = promptLine("사용자 ID 입력: ").trim();
-            if (!USER_ID_PATTERN.matcher(userId).matches()) {
-                System.out.println("오류: 사용자 ID는 영문자로 시작하고 영문자/숫자/_ 만 사용하여 4~20자로 입력해야 합니다.");
-                continue;
-            }
-            if (data.users.containsKey(userId)) {
-                System.out.println("오류: 이미 존재하는 사용자 ID입니다.");
-                continue;
-            }
-            return userId;
+    private String promptNewUserName() {
+        String userName = promptStrictValue("사용자명 입력: ");
+        if (!USER_NAME_PATTERN.matcher(userName).matches()) {
+            abortAction("오류: 사용자명은 영문자로 시작하고 영문자/숫자/_ 만 사용하여 4~20자로 입력해야 합니다.");
         }
+        return userName;
+    }
+
+    private String promptLoginId(String prompt) {
+        String loginId = promptStrictValue(prompt);
+        if (!LOGIN_ID_PATTERN.matcher(loginId).matches()) {
+            abortAction("오류: 로그인 ID는 영문자로 시작하고 영문자/숫자/_ 만 사용하여 4~20자로 입력해야 합니다.");
+        }
+        return loginId;
     }
 
     private String promptPassword() {
-        while (true) {
-            String password = promptLine("비밀번호 입력: ").trim();
-            if (password.length() < 4 || password.length() > 20) {
-                System.out.println("오류: 비밀번호는 4~20자로 입력해야 합니다.");
-                continue;
-            }
-            if (hasForbiddenChars(password)) {
-                System.out.println("오류: 비밀번호에 사용할 수 없는 문자가 포함되어 있습니다.");
-                continue;
-            }
-            return password;
-        }
+        return promptPassword("비밀번호 입력: ");
     }
 
-    private String promptDisplayName() {
-        while (true) {
-            String displayName = promptLine("이름 입력: ").trim();
-            if (displayName.length() < 1 || displayName.length() > 20) {
-                System.out.println("오류: 이름은 1~20자로 입력해야 합니다.");
-                continue;
-            }
-            if (hasForbiddenChars(displayName)) {
-                System.out.println("오류: 이름에 사용할 수 없는 문자가 포함되어 있습니다.");
-                continue;
-            }
-            return displayName;
+    private String promptPassword(String prompt) {
+        String password = promptStrictValue(prompt);
+        if (password.length() < 4 || password.length() > 20) {
+            abortAction("오류: 비밀번호는 4~20자로 입력해야 합니다.");
         }
+        if (hasForbiddenChars(password)) {
+            abortAction("오류: 비밀번호에 사용할 수 없는 문자가 포함되어 있습니다.");
+        }
+        return password;
     }
 
     private String promptRoomId(String prompt) {
-        while (true) {
-            String roomId = promptLine(prompt).trim();
-            if (!ROOM_ID_PATTERN.matcher(roomId).matches()) {
-                System.out.println("오류: 룸 ID 형식이 올바르지 않습니다. 예: R101");
-                continue;
-            }
-            return roomId;
+        String roomId = promptStrictValue(prompt);
+        if (!ROOM_ID_PATTERN.matcher(roomId).matches()) {
+            abortAction("오류: 룸 ID 형식이 올바르지 않습니다. 예: R101");
         }
+        return roomId;
     }
 
     private String promptReservationId(String prompt) {
-        while (true) {
-            String reservationId = promptLine(prompt).trim();
-            if (!RESERVATION_ID_PATTERN.matcher(reservationId).matches()) {
-                System.out.println("오류: 예약번호 형식이 올바르지 않습니다. 예: rv0001");
-                continue;
-            }
-            return reservationId;
+        String reservationId = promptStrictValue(prompt);
+        if (!RESERVATION_ID_PATTERN.matcher(reservationId).matches()) {
+            abortAction("오류: 예약번호 형식이 올바르지 않습니다. 예: rv0001");
         }
+        return reservationId;
     }
 
     private LocalDate promptDate(String prompt) {
-        while (true) {
-            String dateText = promptLine(prompt).trim();
-            try {
-                return LocalDate.parse(dateText, TimeFormats.DATE);
-            } catch (DateTimeParseException e) {
-                System.out.println("오류: 날짜 형식이 올바르지 않습니다. 예: 2026-03-20");
-            }
+        String dateText = promptStrictValue(prompt);
+        try {
+            return LocalDate.parse(dateText, TimeFormats.DATE);
+        } catch (DateTimeParseException e) {
+            abortAction("오류: 날짜 형식이 올바르지 않습니다. 예: 2026-03-20");
+            return null;
         }
     }
 
     private LocalTime promptTime(String prompt) {
-        while (true) {
-            String timeText = promptLine(prompt).trim();
-            try {
-                LocalTime time = LocalTime.parse(timeText, TimeFormats.TIME);
-                if (time.getMinute() != 0) {
-                    System.out.println("오류: 예약 시각은 1시간 단위여야 합니다.");
-                    continue;
-                }
-                return time;
-            } catch (DateTimeParseException e) {
-                System.out.println("오류: 시각 형식이 올바르지 않습니다. 예: 13:00");
+        String timeText = promptStrictValue(prompt);
+        try {
+            LocalTime time = LocalTime.parse(timeText, TimeFormats.TIME);
+            if (time.getMinute() != 0) {
+                abortAction("오류: 예약 시각은 1시간 단위여야 합니다.");
             }
+            return time;
+        } catch (DateTimeParseException e) {
+            abortAction("오류: 시각 형식이 올바르지 않습니다. 예: 13:00");
+            return null;
         }
     }
 
     private LocalDateTime promptDateTime(String prompt) {
-        while (true) {
-            String text = promptLine(prompt).trim();
-            try {
-                return LocalDateTime.parse(text, TimeFormats.DATE_TIME);
-            } catch (DateTimeParseException e) {
-                System.out.println("오류: 날짜/시각 형식이 올바르지 않습니다. 예: 2026-03-20 09:00");
-            }
+        String text = promptStrictValue(prompt);
+        try {
+            return LocalDateTime.parse(text, TimeFormats.DATE_TIME);
+        } catch (DateTimeParseException e) {
+            abortAction("오류: 날짜/시각 형식이 올바르지 않습니다. 예: 2026-03-20 09:00");
+            return null;
         }
     }
 
     private int promptPositiveInt(String prompt) {
-        while (true) {
-            String text = promptLine(prompt).trim();
-            try {
-                int value = Integer.parseInt(text);
-                if (value < 1) {
-                    System.out.println("오류: 1 이상의 정수를 입력해야 합니다.");
-                    continue;
-                }
-                return value;
-            } catch (NumberFormatException e) {
-                System.out.println("오류: 숫자를 입력해야 합니다.");
+        String text = promptStrictValue(prompt);
+        try {
+            int value = Integer.parseInt(text);
+            if (value < 1) {
+                abortAction("오류: 1 이상의 정수를 입력해야 합니다.");
             }
+            return value;
+        } catch (NumberFormatException e) {
+            abortAction("오류: 숫자를 입력해야 합니다.");
+            return -1;
         }
     }
 
@@ -969,6 +1003,29 @@ final class CliApp {
 
     private boolean hasForbiddenChars(String text) {
         return text.indexOf('|') >= 0 || text.indexOf('\n') >= 0 || text.indexOf('\r') >= 0;
+    }
+
+    private String promptStrictValue(String prompt) {
+        String raw = promptLine(prompt);
+        if (!raw.equals(raw.trim())) {
+            abortAction("오류: 입력값 앞뒤에 공백을 넣을 수 없습니다.");
+        }
+        if (raw.isEmpty()) {
+            abortAction("오류: 빈 값을 입력할 수 없습니다.");
+        }
+        return raw;
+    }
+
+    private void abortAction(String message) {
+        System.out.println(message);
+        throw new ActionAbortedException();
+    }
+
+    private void printRecordChange(String label, String before, String after) {
+        System.out.println("변경 전 " + label + " 레코드:");
+        System.out.println(before);
+        System.out.println("변경 후 " + label + " 레코드:");
+        System.out.println(after);
     }
 
     private void printFileErrorAndExit(AppDataException e) {

--- a/src/Domain.java
+++ b/src/Domain.java
@@ -60,13 +60,15 @@ enum ReservationStatus {
 
 final class User {
     final String userId;
+    final String loginId;
     final String password;
     final String userName;
     final Role role;
     final int sourceLine;
 
-    User(String userId, String password, String userName, Role role, int sourceLine) {
+    User(String userId, String loginId, String password, String userName, Role role, int sourceLine) {
         this.userId = userId;
+        this.loginId = loginId;
         this.password = password;
         this.userName = userName;
         this.role = role;
@@ -74,7 +76,7 @@ final class User {
     }
 
     String toRecord() {
-        return String.join("|", "USER", userId, password, userName, role.fileValue());
+        return String.join("|", "USER", userId, loginId, password, userName, role.fileValue());
     }
 }
 
@@ -214,6 +216,29 @@ final class SystemData {
             }
         }
         return String.format("rv%04d", max + 1);
+    }
+
+    String nextUserId() {
+        int max = 0;
+        for (String id : users.keySet()) {
+            if (!id.startsWith("user") || id.length() <= 4) {
+                continue;
+            }
+            try {
+                max = Math.max(max, Integer.parseInt(id.substring(4)));
+            } catch (NumberFormatException ignored) {
+            }
+        }
+        return String.format("user%03d", max + 1);
+    }
+
+    User findUserByLoginId(String loginId) {
+        for (User user : users.values()) {
+            if (user.loginId.equals(loginId)) {
+                return user;
+            }
+        }
+        return null;
     }
 
     List<Room> sortedRooms() {

--- a/src/Exceptions.java
+++ b/src/Exceptions.java
@@ -27,6 +27,12 @@ class FatalAppException extends RuntimeException {
     }
 }
 
+class ActionAbortedException extends RuntimeException {
+    ActionAbortedException() {
+        super();
+    }
+}
+
 class CancelledActionException extends Exception {
     CancelledActionException() {
         super();

--- a/src/TextDataStore.java
+++ b/src/TextDataStore.java
@@ -18,6 +18,8 @@ final class TextDataStore {
     static final String SYSTEM_TIME_FILE = "system_time.txt";
 
     private static final Pattern USER_ID_PATTERN = Pattern.compile("^[A-Za-z][A-Za-z0-9_]{3,19}$");
+    private static final Pattern LOGIN_ID_PATTERN = Pattern.compile("^[A-Za-z][A-Za-z0-9_]{3,19}$");
+    private static final Pattern USER_NAME_PATTERN = Pattern.compile("^[A-Za-z][A-Za-z0-9_]{3,19}$");
     private static final Pattern ROOM_ID_PATTERN = Pattern.compile("^R[0-9]{3}$");
     private static final Pattern RESERVATION_ID_PATTERN = Pattern.compile("^rv[0-9]{4}$");
 
@@ -77,25 +79,33 @@ final class TextDataStore {
     private LinkedHashMap<String, User> parseUsers() throws AppDataException {
         List<LineRecord> lines = readLogicalLines(usersPath, USERS_FILE);
         LinkedHashMap<String, User> users = new LinkedHashMap<>();
+        LinkedHashMap<String, User> usersByLoginId = new LinkedHashMap<>();
         for (LineRecord line : lines) {
-            String[] fields = splitFields(line, USERS_FILE, 5);
+            String[] fields = splitFields(line, USERS_FILE, 6);
             require("USER".equals(fields[0]), USERS_FILE, line.lineNumber, "레코드 접두어는 USER여야 합니다.");
             String userId = fields[1].trim();
-            String password = fields[2].trim();
-            String userName = fields[3].trim();
-            Role role = Role.fromFile(fields[4], USERS_FILE, line.lineNumber);
+            String loginId = fields[2].trim();
+            String password = fields[3].trim();
+            String userName = fields[4].trim();
+            Role role = Role.fromFile(fields[5], USERS_FILE, line.lineNumber);
 
             require(USER_ID_PATTERN.matcher(userId).matches(), USERS_FILE, line.lineNumber,
                     "userId 형식이 올바르지 않습니다.");
+            require(LOGIN_ID_PATTERN.matcher(loginId).matches(), USERS_FILE, line.lineNumber,
+                    "loginId 형식이 올바르지 않습니다.");
             require(password.length() >= 4 && password.length() <= 20, USERS_FILE, line.lineNumber,
                     "password 길이는 4~20이어야 합니다.");
+            validateNoPipeOrNewline(loginId, USERS_FILE, line.lineNumber, "loginId");
             validateNoPipeOrNewline(password, USERS_FILE, line.lineNumber, "password");
-            require(userName.length() >= 1 && userName.length() <= 20, USERS_FILE, line.lineNumber,
-                    "userName 길이는 1~20이어야 합니다.");
+            require(USER_NAME_PATTERN.matcher(userName).matches(), USERS_FILE, line.lineNumber,
+                    "userName 형식이 올바르지 않습니다.");
             validateNoPipeOrNewline(userName, USERS_FILE, line.lineNumber, "userName");
 
-            User prev = users.put(userId, new User(userId, password, userName, role, line.lineNumber));
+            User parsed = new User(userId, loginId, password, userName, role, line.lineNumber);
+            User prev = users.put(userId, parsed);
             require(prev == null, USERS_FILE, line.lineNumber, "중복된 userId가 존재합니다.");
+            User byLoginId = usersByLoginId.put(loginId, parsed);
+            require(byLoginId == null, USERS_FILE, line.lineNumber, "중복된 loginId가 존재합니다.");
         }
         return users;
     }
@@ -343,7 +353,7 @@ final class TextDataStore {
     }
 
     private String defaultUsers() {
-        return "USER|admin|admin1234|관리자|admin\n";
+        return "USER|user001|user001|admin1234|admin|admin\n";
     }
 
     private String defaultRooms() {

--- a/test/RegressionTest.java
+++ b/test/RegressionTest.java
@@ -30,6 +30,7 @@ public class RegressionTest {
         testCheckInBoundarySuccess();
         testCheckInClosedRoomRejected();
         testAdminTimeChangeRejectsPastAndAppliesTransitions();
+        testAllReservationsShowsUserNames();
         testManualMoveSameRoomRejectedAndThenSucceeds();
         testCapacityChangeWithHistoricalCompletedReservation();
         testCapacityChangeImpactedSameRoomRejectedAndMoveSuccess();
@@ -44,7 +45,7 @@ public class RegressionTest {
     private static void testAutoNoShowTransition() throws Exception {
         Path root = Files.createTempDirectory("study-room-test-");
         writeData(root,
-                users("user011", "pw1234", "회원1"),
+                users("user011", "pw1234", "bonsu"),
                 "ROOM|R101|A룸|4|OPEN\n",
                 "RESV|rv0001|user011|R101|2026-03-20|11:00|12:00|2|RESERVED|2026-03-19 09:00|-\n",
                 "NOW|2026-03-20 11:11\n");
@@ -63,7 +64,7 @@ public class RegressionTest {
     private static void testNextReservationId() throws Exception {
         Path root = Files.createTempDirectory("study-room-id-test-");
         writeData(root,
-                users("user011", "pw1234", "회원1"),
+                users("user011", "pw1234", "bonsu"),
                 "ROOM|R101|A룸|4|OPEN\n",
                 "RESV|rv0001|user011|R101|2026-03-20|11:00|12:00|2|RESERVED|2026-03-19 09:00|-\n"
                         + "RESV|rv0003|user011|R101|2026-03-21|11:00|12:00|2|RESERVED|2026-03-19 10:00|-\n",
@@ -79,7 +80,7 @@ public class RegressionTest {
     private static void testHistoricalCompletedReservationCanExceedCurrentCapacity() throws Exception {
         Path root = Files.createTempDirectory("study-room-capacity-test-");
         writeData(root,
-                users("user011", "pw1234", "회원1"),
+                users("user011", "pw1234", "bonsu"),
                 "ROOM|R101|A룸|4|OPEN\n",
                 "RESV|rv0001|user011|R101|2026-03-20|11:00|12:00|6|COMPLETED|2026-03-19 09:00|2026-03-20 10:55\n",
                 "NOW|2026-03-20 13:00\n");
@@ -93,7 +94,7 @@ public class RegressionTest {
     private static void testSameRoomMoveRejected() throws Exception {
         Path root = Files.createTempDirectory("study-room-move-test-");
         writeData(root,
-                users("user011", "pw1234", "회원1"),
+                users("user011", "pw1234", "bonsu"),
                 "ROOM|R101|A룸|4|OPEN\n"
                         + "ROOM|R102|B룸|6|OPEN\n",
                 "RESV|rv0001|user011|R101|2026-03-21|11:00|12:00|2|RESERVED|2026-03-20 09:00|-\n",
@@ -114,7 +115,7 @@ public class RegressionTest {
         Path root = createCliRoot();
         String output = runCli(root, "0\n");
         assertContains(output, "[비로그인 메뉴]");
-        assertFileContains(root, "users.txt", "USER|admin|admin1234|관리자|admin");
+        assertFileContains(root, "users.txt", "USER|user001|user001|admin1234|admin|admin");
         assertFileContains(root, "rooms.txt", "ROOM|R101|A룸|4|OPEN");
         assertFileContains(root, "system_time.txt", "NOW|2026-03-20 09:00");
     }
@@ -122,7 +123,7 @@ public class RegressionTest {
     private static void testInvalidFileSyntaxStopsStartup() throws Exception {
         Path root = createCliRoot();
         writeData(root,
-                users("user011", "pw1234", "본수"),
+                users("user011", "pw1234", "bonsu"),
                 baseRooms(),
                 "RESV|broken|line\n",
                 "NOW|2026-03-20 09:00\n");
@@ -137,16 +138,15 @@ public class RegressionTest {
 
         String input = lines(
                 "1",
-                "admin",
-                "newuser",
+                "user023",
                 "pw12",
-                "새사용자",
+                "bonsu",
                 "0");
         String output = runCli(root, input);
 
-        assertContains(output, "오류: 이미 존재하는 사용자 ID입니다.");
         assertContains(output, "회원가입이 완료되었습니다.");
-        assertFileContains(root, "users.txt", "USER|newuser|pw12|새사용자|member");
+        assertContains(output, "발급된 사용자 ID: user023");
+        assertFileContains(root, "users.txt", "USER|user023|user023|pw12|bonsu|member");
     }
 
     private static void testLoginFailureAndSuccess() throws Exception {
@@ -165,7 +165,7 @@ public class RegressionTest {
         String output = runCli(root, input);
 
         assertContains(output, "오류: 비밀번호가 일치하지 않습니다.");
-        assertContains(output, "로그인 성공: 본수 (member)");
+        assertContains(output, "로그인 성공: bonsu (role: member)");
     }
 
     private static void testMemberTimeChangeSuccess() throws Exception {
@@ -176,7 +176,7 @@ public class RegressionTest {
                 "2",
                 "user011",
                 "pw1234",
-                "2",
+                "1",
                 "2026-03-20 10:00",
                 "0",
                 "0"));
@@ -199,7 +199,7 @@ public class RegressionTest {
                 "2",
                 "user011",
                 "pw1234",
-                "3",
+                "2",
                 "2026-03-20",
                 "13:00",
                 "15:00",
@@ -219,7 +219,7 @@ public class RegressionTest {
                 "2",
                 "user011",
                 "pw1234",
-                "4",
+                "3",
                 "2026-03-20",
                 "13:00",
                 "15:00",
@@ -241,7 +241,7 @@ public class RegressionTest {
                 "2",
                 "user011",
                 "pw1234",
-                "4",
+                "3",
                 "2026-03-20",
                 "13:30",
                 "13:00",
@@ -267,7 +267,7 @@ public class RegressionTest {
                 "2",
                 "user011",
                 "pw1234",
-                "4",
+                "3",
                 "2026-03-20",
                 "13:00",
                 "15:00",
@@ -292,7 +292,7 @@ public class RegressionTest {
                 "2",
                 "user011",
                 "pw1234",
-                "4",
+                "3",
                 "2026-03-20",
                 "13:00",
                 "15:00",
@@ -317,7 +317,7 @@ public class RegressionTest {
                 "2",
                 "user011",
                 "pw1234",
-                "5",
+                "4",
                 "rv0001",
                 "0",
                 "0");
@@ -339,7 +339,7 @@ public class RegressionTest {
                 "2",
                 "user011",
                 "pw1234",
-                "5",
+                "4",
                 "rv0001",
                 "0",
                 "0");
@@ -360,7 +360,7 @@ public class RegressionTest {
                 "2",
                 "user011",
                 "pw1234",
-                "7",
+                "6",
                 "rv0001",
                 "0",
                 "0");
@@ -381,7 +381,7 @@ public class RegressionTest {
                 "2",
                 "user011",
                 "pw1234",
-                "7",
+                "6",
                 "rv0001",
                 "0",
                 "0");
@@ -404,7 +404,7 @@ public class RegressionTest {
                 "2",
                 "user011",
                 "pw1234",
-                "7",
+                "6",
                 "rv0001",
                 "0",
                 "0");
@@ -424,11 +424,11 @@ public class RegressionTest {
 
         String input = lines(
                 "2",
-                "admin",
+                "user001",
                 "admin1234",
-                "2",
+                "1",
                 "2026-03-20 08:00",
-                "2",
+                "1",
                 "2026-03-20 11:11",
                 "0",
                 "0");
@@ -442,6 +442,32 @@ public class RegressionTest {
         assertFileContains(root, "reservations.txt", "RESV|rv0002|user022|R102|2026-03-20|09:00|10:00|2|COMPLETED|2026-03-20 08:30|2026-03-20 08:55");
     }
 
+    private static void testAllReservationsShowsUserNames() throws Exception {
+        Path root = createCliRoot();
+        writeData(root,
+                baseUsers(),
+                baseRooms(),
+                "RESV|rv0001|user011|R101|2026-03-21|11:00|12:00|2|RESERVED|2026-03-20 09:00|-\n"
+                        + "RESV|rv0002|user022|R102|2026-03-21|13:00|14:00|3|RESERVED|2026-03-20 09:30|-\n",
+                "NOW|2026-03-20 09:00\n");
+
+        String output = runCli(root, lines(
+                "2",
+                "user001",
+                "admin1234",
+                "2",
+                "0",
+                "0"));
+
+        assertContains(output, "resvId");
+        assertContains(output, "userId");
+        assertContains(output, "userName");
+        assertContains(output, "user011");
+        assertContains(output, "user022");
+        assertContains(output, "bonsu");
+        assertContains(output, "minseo");
+    }
+
     private static void testManualMoveSameRoomRejectedAndThenSucceeds() throws Exception {
         Path root = createCliRoot();
         writeData(root,
@@ -452,12 +478,12 @@ public class RegressionTest {
 
         String input = lines(
                 "2",
-                "admin",
+                "user001",
                 "admin1234",
-                "4",
+                "3",
                 "rv0001",
                 "R101",
-                "4",
+                "3",
                 "rv0001",
                 "R102",
                 "0",
@@ -465,6 +491,8 @@ public class RegressionTest {
         String output = runCli(root, input);
 
         assertContains(output, "오류: 현재 룸과 다른 룸으로만 이동할 수 있습니다.");
+        assertContains(output, "변경 전 예약 레코드:");
+        assertContains(output, "변경 후 예약 레코드:");
         assertContains(output, "예약 조정이 완료되었습니다.");
         assertFileContains(root, "reservations.txt", "RESV|rv0001|user011|R102|2026-03-21|11:00|12:00|2|RESERVED|2026-03-20 09:00|-");
     }
@@ -480,9 +508,9 @@ public class RegressionTest {
 
         String output = runCli(root, lines(
                 "2",
-                "admin",
+                "user001",
                 "admin1234",
-                "5",
+                "4",
                 "2",
                 "R101",
                 "4",
@@ -490,6 +518,8 @@ public class RegressionTest {
                 "0",
                 "0"));
 
+        assertContains(output, "변경 전 ROOM 레코드:");
+        assertContains(output, "변경 후 ROOM 레코드:");
         assertContains(output, "룸 최대 수용 인원이 변경되었습니다.");
         assertFileContains(root, "rooms.txt", "ROOM|R101|A룸|4|OPEN");
     }
@@ -505,9 +535,9 @@ public class RegressionTest {
 
         String output = runCli(root, lines(
                 "2",
-                "admin",
+                "user001",
                 "admin1234",
-                "5",
+                "4",
                 "2",
                 "R101",
                 "4",
@@ -519,8 +549,14 @@ public class RegressionTest {
                 "0",
                 "0"));
 
+        assertContains(output, "현재 CHECKED_IN 예약 인원 검사 통과");
         assertContains(output, "영향 예약이 있어 처리 흐름을 시작합니다.");
         assertContains(output, "오류: 현재 룸과 다른 룸으로만 이동할 수 있습니다.");
+        assertContains(output, "영향 예약 처리가 완료되었습니다.");
+        assertContains(output, "변경 전 RESV 레코드:");
+        assertContains(output, "변경 후 RESV 레코드:");
+        assertContains(output, "변경 전 ROOM 레코드:");
+        assertContains(output, "변경 후 ROOM 레코드:");
         assertContains(output, "룸 최대 수용 인원이 변경되었습니다.");
         assertFileContains(root, "rooms.txt", "ROOM|R101|A룸|4|OPEN");
         assertFileContains(root, "reservations.txt", "RESV|rv0001|user011|R102|2026-03-21|11:00|12:00|6|RESERVED|2026-03-20 09:00|-");
@@ -537,9 +573,9 @@ public class RegressionTest {
 
         String output = runCli(root, lines(
                 "2",
-                "admin",
+                "user001",
                 "admin1234",
-                "5",
+                "4",
                 "2",
                 "R101",
                 "4",
@@ -563,9 +599,9 @@ public class RegressionTest {
 
         String output = runCli(root, lines(
                 "2",
-                "admin",
+                "user001",
                 "admin1234",
-                "5",
+                "4",
                 "3",
                 "R101",
                 "0",
@@ -586,9 +622,9 @@ public class RegressionTest {
 
         String output = runCli(root, lines(
                 "2",
-                "admin",
+                "user001",
                 "admin1234",
-                "5",
+                "4",
                 "3",
                 "R101",
                 "2",
@@ -597,7 +633,9 @@ public class RegressionTest {
                 "0"));
 
         assertContains(output, "영향 예약이 있어 처리 흐름을 시작합니다.");
-        assertContains(output, "룸이 임시 휴업 상태(CLOSED)로 변경되었습니다.");
+        assertContains(output, "변경 전 ROOM 레코드:");
+        assertContains(output, "변경 후 ROOM 레코드:");
+        assertContains(output, "룸이 임시 휴업 처리되었습니다.");
         assertFileContains(root, "rooms.txt", "ROOM|R101|A룸|4|CLOSED");
         assertFileNotContains(root, "reservations.txt", "rv0001");
     }
@@ -613,15 +651,17 @@ public class RegressionTest {
 
         String output = runCli(root, lines(
                 "2",
-                "admin",
+                "user001",
                 "admin1234",
-                "5",
+                "4",
                 "4",
                 "R101",
                 "0",
                 "0",
                 "0"));
 
+        assertContains(output, "변경 전 ROOM 레코드:");
+        assertContains(output, "변경 후 ROOM 레코드:");
         assertContains(output, "룸 운영이 재개되었습니다.");
         assertFileContains(root, "rooms.txt", "ROOM|R101|A룸|4|OPEN");
     }
@@ -666,13 +706,13 @@ public class RegressionTest {
     }
 
     private static String baseUsers() {
-        return users("user011", "pw1234", "본수")
-                + "USER|user022|pw5678|다른회원|member\n";
+        return users("user011", "pw1234", "bonsu")
+                + "USER|user022|user022|pw5678|minseo|member\n";
     }
 
     private static String users(String userId, String password, String userName) {
-        return "USER|admin|admin1234|관리자|admin\n"
-                + "USER|" + userId + "|" + password + "|" + userName + "|member\n";
+        return "USER|user001|user001|admin1234|admin|admin\n"
+                + "USER|" + userId + "|" + userId + "|" + password + "|" + userName + "|member\n";
     }
 
     private static String baseRooms() {


### PR DESCRIPTION
## What changed
- aligned user storage with the final spec by adding `loginId` to `users.txt`
- switched signup/login flows to use `loginId + password` while keeping auto-issued `userId`
- tightened CLI input handling so malformed field input aborts back to the parent menu instead of looping in-field
- updated regression coverage and README/example data to match the new auth model

## Why
The final planning document expects login to be based on `loginId`, not `userId`, and the stored user record format needed to reflect that requirement consistently across parsing, serialization, CLI behavior, and tests.

## Impact
- user records now use `USER|userId|loginId|password|userName|role`
- existing v2 behavior around reservations/admin flows stays intact, but auth and related prompts now follow the final spec more closely

## Validation
- `./build.sh`
- `mkdir -p out/test-classes && javac -encoding UTF-8 -d out/test-classes src/*.java test/RegressionTest.java && java -cp out/test-classes RegressionTest`
