### PR TITLE
Align jar output with root distribution layout

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,13 +23,35 @@ macOS / Linux:
 Windows:
 
 ```powershell
-.\gradlew.bat run
+java -jar study-room-cli.jar
 ```
 
 macOS / Linux:
 
 ```bash
-./gradlew run
+java -jar study-room-cli.jar
+```
+
+기획서 기준 배포 형태:
+
+```text
+프로젝트 루트/
+  study-room-cli.jar
+  data/
+```
+
+Gradle로 JAR를 다시 만들 때는 아래 명령을 사용합니다.
+
+Windows:
+
+```powershell
+.\gradlew.bat jar
+```
+
+macOS / Linux:
+
+```bash
+./gradlew jar
 ```
 
 ## 기본 admin 계정

--- a/build.gradle
+++ b/build.gradle
@@ -27,7 +27,7 @@ tasks.withType(JavaCompile).configureEach {
 
 tasks.named('jar') {
     archiveFileName = 'study-room-cli.jar'
-    destinationDirectory = layout.buildDirectory.dir('.')
+    destinationDirectory = layout.projectDirectory
     manifest {
         attributes('Main-Class': application.mainClass.get())
     }


### PR DESCRIPTION
## Summary
- generate study-room-cli.jar in the project root instead of out/
- update the README to document the root-level execution flow
- align the built distribution layout with the project spec

## Testing
- .\\gradlew.bat jar
- java -jar study-room-cli.jar

Closes #19