### PR TITLE
Handle check-in-window reservations during room-condition changes

### DIFF
--- a/src/main/java/ku/com/CliApp.java
+++ b/src/main/java/ku/com/CliApp.java
@@ -686,8 +686,7 @@ final class CliApp {
         List<Reservation> impacted = new ArrayList<>();
         for (Reservation reservation : data.sortedReservations()) {
             if (reservation.roomId.equals(roomId)
-                    && reservation.status == ReservationStatus.RESERVED
-                    && reservation.startDateTime().isAfter(data.currentTime)
+                    && isReservedStillAwaitingUse(reservation, data.currentTime)
                     && reservation.partySize > newCapacity) {
                 impacted.add(reservation);
             }
@@ -699,8 +698,7 @@ final class CliApp {
         List<Reservation> impacted = new ArrayList<>();
         for (Reservation reservation : data.sortedReservations()) {
             if (reservation.roomId.equals(roomId)
-                    && reservation.status == ReservationStatus.RESERVED
-                    && reservation.startDateTime().isAfter(data.currentTime)) {
+                    && isReservedStillAwaitingUse(reservation, data.currentTime)) {
                 impacted.add(reservation);
             }
         }
@@ -710,12 +708,16 @@ final class CliApp {
     private boolean hasFutureReservedInRoom(SystemData data, String roomId) {
         for (Reservation reservation : data.reservations.values()) {
             if (reservation.roomId.equals(roomId)
-                    && reservation.status == ReservationStatus.RESERVED
-                    && reservation.startDateTime().isAfter(data.currentTime)) {
+                    && isReservedStillAwaitingUse(reservation, data.currentTime)) {
                 return true;
             }
         }
         return false;
+    }
+
+    private boolean isReservedStillAwaitingUse(Reservation reservation, LocalDateTime now) {
+        return reservation.status == ReservationStatus.RESERVED
+                && !now.isAfter(reservation.startDateTime().plusMinutes(10));
     }
 
     private boolean hasActiveReservationOverCapacity(SystemData data, String roomId, int newCapacity) {

--- a/src/test/java/ku/com/RegressionTest.java
+++ b/src/test/java/ku/com/RegressionTest.java
@@ -35,9 +35,11 @@ public class RegressionTest {
         testAllReservationsShowsUserNames();
         testManualMoveSameRoomRejectedAndThenSucceeds();
         testCapacityChangeWithHistoricalCompletedReservation();
+        testCapacityChangeCheckInWindowReservedHandledAsImpacted();
         testCapacityChangeImpactedSameRoomRejectedAndMoveSuccess();
         testCapacityChangeRollbackRestoresState();
         testCloseRoomWithCheckedInReservationRejected();
+        testCloseRoomCheckInWindowReservedHandledAsImpacted();
         testCloseRoomImpactedDeleteAndSucceeds();
         testOpenRoomSuccess();
 
@@ -526,6 +528,35 @@ public class RegressionTest {
         assertFileContains(root, "rooms.txt", "ROOM|R101|A룸|4|OPEN");
     }
 
+    private static void testCapacityChangeCheckInWindowReservedHandledAsImpacted() throws Exception {
+        Path root = createCliRoot();
+        writeData(root,
+                baseUsers(),
+                "ROOM|R101|A룸|6|OPEN\n"
+                        + "ROOM|R102|B룸|6|OPEN\n",
+                "RESV|rv0001|user011|R101|2026-03-20|09:00|10:00|5|RESERVED|2026-03-20 08:00|-\n",
+                "NOW|2026-03-20 09:05\n");
+
+        String output = runCli(root, lines(
+                "2",
+                "user001",
+                "admin1234",
+                "4",
+                "2",
+                "R101",
+                "4",
+                "2",
+                "0",
+                "0",
+                "0"));
+
+        assertContains(output, "영향 예약이 있어 처리 흐름을 시작합니다.");
+        assertContains(output, "영향 예약 처리가 완료되었습니다.");
+        assertContains(output, "룸 최대 수용 인원이 변경되었습니다.");
+        assertFileContains(root, "rooms.txt", "ROOM|R101|A룸|4|OPEN");
+        assertFileNotContains(root, "reservations.txt", "rv0001");
+    }
+
     private static void testCapacityChangeImpactedSameRoomRejectedAndMoveSuccess() throws Exception {
         Path root = createCliRoot();
         writeData(root,
@@ -612,6 +643,32 @@ public class RegressionTest {
 
         assertContains(output, "오류: 현재 체크인 중인 예약이 있어 즉시 휴업할 수 없습니다.");
         assertFileContains(root, "rooms.txt", "ROOM|R101|A룸|4|OPEN");
+    }
+
+    private static void testCloseRoomCheckInWindowReservedHandledAsImpacted() throws Exception {
+        Path root = createCliRoot();
+        writeData(root,
+                baseUsers(),
+                baseRooms(),
+                "RESV|rv0001|user011|R101|2026-03-20|09:00|10:00|2|RESERVED|2026-03-20 08:00|-\n",
+                "NOW|2026-03-20 09:05\n");
+
+        String output = runCli(root, lines(
+                "2",
+                "user001",
+                "admin1234",
+                "4",
+                "3",
+                "R101",
+                "2",
+                "0",
+                "0",
+                "0"));
+
+        assertContains(output, "영향 예약이 있어 처리 흐름을 시작합니다.");
+        assertContains(output, "룸이 임시 휴업 처리되었습니다.");
+        assertFileContains(root, "rooms.txt", "ROOM|R101|A룸|4|CLOSED");
+        assertFileNotContains(root, "reservations.txt", "rv0001");
     }
 
     private static void testCloseRoomImpactedDeleteAndSucceeds() throws Exception {


### PR DESCRIPTION
## Summary
- treat check-in-window RESERVED bookings as impacted during room capacity changes
- treat check-in-window RESERVED bookings as impacted during room close operations
- add regression coverage for both issue #27 reproduction paths

Closes #27

## Scope
- fixes issue #27 A and B
- issue #27 C (leading-zero menu input) is intentionally not included here

## Verification
- sh gradlew test regressionTest