### PR TITLE
Reject proleptic years and Unicode-padded input

### DIFF
--- a/src/main/java/ku/com/CliApp.java
+++ b/src/main/java/ku/com/CliApp.java
@@ -952,8 +952,11 @@ final class CliApp {
     private LocalDate promptDate(String prompt) {
         String dateText = promptStrictValue(prompt);
         try {
-            return LocalDate.parse(dateText, TimeFormats.DATE);
+            return TimeFormats.parseDate(dateText, "input", 0, "날짜");
         } catch (DateTimeParseException e) {
+            abortAction("오류: 날짜 형식이 올바르지 않습니다. 예: 2026-03-20");
+            return null;
+        } catch (AppDataException e) {
             abortAction("오류: 날짜 형식이 올바르지 않습니다. 예: 2026-03-20");
             return null;
         }
@@ -976,8 +979,11 @@ final class CliApp {
     private LocalDateTime promptDateTime(String prompt) {
         String text = promptStrictValue(prompt);
         try {
-            return LocalDateTime.parse(text, TimeFormats.DATE_TIME);
+            return TimeFormats.parseDateTime(text, "input", 0, "날짜/시각");
         } catch (DateTimeParseException e) {
+            abortAction("오류: 날짜/시각 형식이 올바르지 않습니다. 예: 2026-03-20 09:00");
+            return null;
+        } catch (AppDataException e) {
             abortAction("오류: 날짜/시각 형식이 올바르지 않습니다. 예: 2026-03-20 09:00");
             return null;
         }
@@ -1011,13 +1017,24 @@ final class CliApp {
 
     private String promptStrictValue(String prompt) {
         String raw = promptLine(prompt);
-        if (!raw.equals(raw.trim())) {
+        if (hasOuterWhitespace(raw)) {
             abortAction("오류: 입력값 앞뒤에 공백을 넣을 수 없습니다.");
         }
         if (raw.isEmpty()) {
             abortAction("오류: 빈 값을 입력할 수 없습니다.");
         }
         return raw;
+    }
+
+    private boolean hasOuterWhitespace(String text) {
+        if (text.isEmpty()) {
+            return false;
+        }
+        return isSpaceLike(text.charAt(0)) || isSpaceLike(text.charAt(text.length() - 1));
+    }
+
+    private boolean isSpaceLike(char ch) {
+        return Character.isWhitespace(ch) || Character.isSpaceChar(ch);
     }
 
     private void abortAction(String message) {

--- a/src/main/java/ku/com/TimeFormats.java
+++ b/src/main/java/ku/com/TimeFormats.java
@@ -17,7 +17,9 @@ final class TimeFormats {
 
     static LocalDate parseDate(String raw, String fileName, int lineNumber, String fieldName) throws AppDataException {
         try {
-            return LocalDate.parse(raw, DATE);
+            LocalDate parsed = LocalDate.parse(raw, DATE);
+            requirePositiveYear(parsed.getYear(), fileName, lineNumber, fieldName);
+            return parsed;
         } catch (DateTimeParseException e) {
             throw new AppDataException(fileName, lineNumber, fieldName + " 형식이 올바르지 않습니다.");
         }
@@ -33,8 +35,16 @@ final class TimeFormats {
 
     static LocalDateTime parseDateTime(String raw, String fileName, int lineNumber, String fieldName) throws AppDataException {
         try {
-            return LocalDateTime.parse(raw, DATE_TIME);
+            LocalDateTime parsed = LocalDateTime.parse(raw, DATE_TIME);
+            requirePositiveYear(parsed.getYear(), fileName, lineNumber, fieldName);
+            return parsed;
         } catch (DateTimeParseException e) {
+            throw new AppDataException(fileName, lineNumber, fieldName + " 형식이 올바르지 않습니다.");
+        }
+    }
+
+    private static void requirePositiveYear(int year, String fileName, int lineNumber, String fieldName) throws AppDataException {
+        if (year <= 0) {
             throw new AppDataException(fileName, lineNumber, fieldName + " 형식이 올바르지 않습니다.");
         }
     }

--- a/src/test/java/ku/com/RegressionTest.java
+++ b/src/test/java/ku/com/RegressionTest.java
@@ -61,6 +61,7 @@ public class RegressionTest {
         testCreateReservationRejectsTooLongWindow();
         testCreateReservationRejectsInvalidRoomIdFormat();
         testCreateReservationRejectsNonexistentRoomId();
+        testCreateReservationRejectsZeroYearDate();
         testCreateReservationRejectsZeroPartySize();
         testCreateReservationRejectsCapacityOverflow();
         testCreateReservationRejectsRoomOverlap();
@@ -94,6 +95,9 @@ public class RegressionTest {
         testCloseRoomCheckInWindowReservedHandledAsImpacted();
         testCloseRoomImpactedDeleteAndSucceeds();
         testOpenRoomSuccess();
+        testSignupRejectsLeadingIdeographicSpaceInPassword();
+        testDataFileRejectsZeroYearDate();
+        testDataFileRejectsNegativeYearDate();
 
         System.out.println("Regression tests passed.");
     }
@@ -462,6 +466,20 @@ public class RegressionTest {
                 "0"));
 
         assertContains(output, "오류: 비밀번호는 4~20자로 입력해야 합니다.");
+    }
+
+    private static void testSignupRejectsLeadingIdeographicSpaceInPassword() throws Exception {
+        Path root = createCliRoot();
+        writeData(root, baseUsers(), baseRooms(), "", "NOW|2026-03-20 09:00\n");
+
+        String output = runCli(root, lines(
+                "1",
+                "user023",
+                "\u3000pw12",
+                "bonsu",
+                "0"));
+
+        assertContains(output, "오류: 입력값 앞뒤에 공백을 넣을 수 없습니다.");
     }
 
     private static void testMenuInvalidChoiceRepromptsInPlace() throws Exception {
@@ -879,6 +897,26 @@ public class RegressionTest {
                 "0"));
 
         assertContains(output, "오류: 존재하지 않는 룸 ID입니다.");
+    }
+
+    private static void testCreateReservationRejectsZeroYearDate() throws Exception {
+        Path root = createCliRoot();
+        writeData(root, baseUsers(), baseRooms(), "", "NOW|2026-03-20 09:00\n");
+
+        String output = runCli(root, lines(
+                "2",
+                "user011",
+                "pw1234",
+                "3",
+                "0000-01-01",
+                "13:00",
+                "14:00",
+                "2",
+                "R102",
+                "0",
+                "0"));
+
+        assertContains(output, "오류: 날짜 형식이 올바르지 않습니다. 예: 2026-03-20");
     }
 
     private static void testCreateReservationRejectsZeroPartySize() throws Exception {
@@ -1659,6 +1697,30 @@ public class RegressionTest {
         assertContains(output, "변경 후 ROOM 레코드:");
         assertContains(output, "룸 운영이 재개되었습니다.");
         assertFileContains(root, "rooms.txt", "ROOM|R101|A룸|4|OPEN");
+    }
+
+    private static void testDataFileRejectsZeroYearDate() throws Exception {
+        Path root = createCliRoot();
+        writeData(root,
+                baseUsers(),
+                baseRooms(),
+                "RESV|rv0001|user011|R101|0000-01-01|13:00|14:00|2|RESERVED|2026-03-20 09:00|-\n",
+                "NOW|2026-03-20 09:00\n");
+
+        String output = runCli(root, "");
+        assertContains(output, "[파일 오류] reservations.txt 1행: date 형식이 올바르지 않습니다.");
+    }
+
+    private static void testDataFileRejectsNegativeYearDate() throws Exception {
+        Path root = createCliRoot();
+        writeData(root,
+                baseUsers(),
+                baseRooms(),
+                "RESV|rv0001|user011|R101|-0001-01-01|13:00|14:00|2|RESERVED|2026-03-20 09:00|-\n",
+                "NOW|2026-03-20 09:00\n");
+
+        String output = runCli(root, "");
+        assertContains(output, "[파일 오류] reservations.txt 1행: date 형식이 올바르지 않습니다.");
     }
 
     private static Path createCliRoot() throws Exception {


### PR DESCRIPTION
## Summary
- reject zero and negative years in shared date/date-time parsing
- route CLI date parsing through the shared validation logic
- reject non-ASCII leading/trailing whitespace in strict input handling
- add regression coverage for zero-year, negative-year, and ideographic-space cases

Closes #32

## Verification
- sh gradlew test regressionTest