### PR TITLE
refactor: 개행문자 검증 로직 수정

### DIFF
--- a/src/main/java/ku/com/CliApp.java
+++ b/src/main/java/ku/com/CliApp.java
@@ -1012,7 +1012,8 @@ final class CliApp {
     }
 
     private boolean hasForbiddenChars(String text) {
-        return text.indexOf('|') >= 0 || text.indexOf('\n') >= 0 || text.indexOf('\r') >= 0;
+        return text.contains("|") || text.contains("\n") || text.contains("\r") ||
+                text.contains("\\n") || text.contains("\\r");
     }
 
     private String promptStrictValue(String prompt) {

--- a/src/main/java/ku/com/TextDataStore.java
+++ b/src/main/java/ku/com/TextDataStore.java
@@ -293,7 +293,8 @@ final class TextDataStore {
     }
 
     private void validateNoPipeOrNewline(String value, String fileName, int lineNumber, String fieldName) throws AppDataException {
-        if (value.indexOf('|') >= 0 || value.indexOf('\n') >= 0 || value.indexOf('\r') >= 0) {
+        if (value.contains("|") || value.contains("\n") || value.contains("\r") ||
+                value.contains("\\n") || value.contains("\\r")) {
             throw new AppDataException(fileName, lineNumber, fieldName + "에 사용할 수 없는 문자가 포함되어 있습니다.");
         }
     }


### PR DESCRIPTION
# 문제
개행문자 파싱을 `'\n'` 형식으로 해서 문자열에서 파싱하지 못하는 이슈

# 해결
* `"\n"` 형식으로 변경하여 문자열에서 파싱이 가능하도록 변경. 
* `indexOf() > 0` 의 형식에서 더 직관적인 `contains()` 메서드로 변경
* `"\n"`, `"\\n"` 두 형식 모두 exception을 발생시키도록 수정.
