### PR TITLE
Implement second-round reservation rules

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ macOS / Linux:
 
 - `users.txt`: `USER|userId|loginId|password|userName|role`
 - `rooms.txt`: `ROOM|roomId|roomName|maxCapacity|roomStatus`
-- `reservations.txt`: `RESV|reservationId|userId|roomId|date|startTime|endTime|partySize|status|createdAt|checkedInAt`
+- `reservations.txt`: `RESV|reservationId|userId|roomId|date|startTime|endTime|partySize|status|createdAt|checkedInAt|extensionCount`
 - `system_time.txt`: `NOW|yyyy-MM-dd HH:mm`
 
 공통 규칙:

--- a/src/main/java/ku/com/CliApp.java
+++ b/src/main/java/ku/com/CliApp.java
@@ -13,7 +13,7 @@ import java.util.ArrayList;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
-import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
 import java.util.Scanner;
 import java.util.Set;
 import java.util.regex.Pattern;
@@ -24,12 +24,17 @@ final class CliApp {
     private static final Pattern ROOM_ID_PATTERN = Pattern.compile("^R[0-9]{3}$");
     private static final Pattern RESERVATION_ID_PATTERN = Pattern.compile("^rv[0-9]{4}$");
 
-    private final Scanner scanner = new Scanner(System.in,
-            Charset.forName(System.getProperty("native.encoding", "UTF-8")));
+    private final Scanner scanner = new Scanner(System.in, StandardCharsets.UTF_8);
     private final TextDataStore store = new TextDataStore(resolveProjectRoot());
 
     private String loggedInUserId;
     private Role loggedInRole;
+
+    private record MemberStanding(int recentNoShowCount, LocalDateTime penaltyUntil, boolean excellent) {
+        boolean underPenalty(LocalDateTime now) {
+            return recentNoShowCount > 0 && penaltyUntil != null && now.isBefore(penaltyUntil);
+        }
+    }
 
     private static Path resolveProjectRoot() {
         try {
@@ -109,9 +114,10 @@ final class CliApp {
         System.out.println("4. 예약 취소");
         System.out.println("5. 나의 예약 조회");
         System.out.println("6. 체크인");
+        System.out.println("7. 예약 연장(우수회원 전용)");
         System.out.println("0. 로그아웃");
 
-        int menu = promptMenuChoice(Set.of(0, 1, 2, 3, 4, 5, 6));
+        int menu = promptMenuChoice(Set.of(0, 1, 2, 3, 4, 5, 6, 7));
         try {
             switch (menu) {
                 case 1 -> handleChangeCurrentTime();
@@ -120,6 +126,7 @@ final class CliApp {
                 case 4 -> handleCancelReservation();
                 case 5 -> handleMyReservations();
                 case 6 -> handleCheckIn();
+                case 7 -> handleExtendReservation();
                 case 0 -> handleLogout();
                 default -> throw new IllegalStateException();
             }
@@ -163,6 +170,10 @@ final class CliApp {
             return;
         }
         String userId = data.nextUserId();
+        if (userId == null) {
+            System.out.println("오류: 더 이상 회원을 추가할 수 없습니다.");
+            return;
+        }
 
         data.users.put(userId, new User(userId, loginId, password, userName, Role.MEMBER, 0));
         store.saveAll(data);
@@ -187,6 +198,16 @@ final class CliApp {
         loggedInUserId = user.userId;
         loggedInRole = user.role;
         System.out.println("로그인 성공: " + user.userName + " (role: " + user.role.fileValue() + ")");
+        if (user.role == Role.MEMBER) {
+            MemberStanding standing = calculateMemberStanding(data, user.userId);
+            System.out.println("회원 상태: " + (standing.excellent ? "우수회원" : "일반회원"));
+            if (standing.underPenalty(data.currentTime)) {
+                System.out.println("패널티 상태: 패널티 대상");
+                System.out.println("패널티 해제 시각: " + TimeFormats.formatDateTime(standing.penaltyUntil));
+            } else {
+                System.out.println("패널티 상태: 없음");
+            }
+        }
     }
 
     private void handleLogout() {
@@ -292,7 +313,19 @@ final class CliApp {
             return;
         }
 
+        MemberStanding standing = calculateMemberStanding(data, loggedInUserId);
+        if (standing.underPenalty(data.currentTime)) {
+            System.out.println("오류: 노쇼 패널티로 "
+                    + TimeFormats.formatDateTime(standing.penaltyUntil)
+                    + " 이후 예약 신청이 가능합니다.");
+            return;
+        }
+
         String reservationId = data.nextReservationId();
+        if (reservationId == null) {
+            System.out.println("오류: 더 이상 예약을 추가할 수 없습니다.");
+            return;
+        }
         Reservation reservation = new Reservation(
                 reservationId,
                 loggedInUserId,
@@ -304,6 +337,7 @@ final class CliApp {
                 ReservationStatus.RESERVED,
                 data.currentTime,
                 null,
+                0,
                 0);
         data.reservations.put(reservationId, reservation);
         store.saveAll(data);
@@ -361,7 +395,7 @@ final class CliApp {
         for (Reservation reservation : mine) {
             Room room = data.rooms.get(reservation.roomId);
             String roomName = room == null ? "-" : room.roomName;
-            System.out.printf("%-8s %-6s %-10s %-10s %-5s %-5s %-4d %-12s%n",
+            System.out.printf("%-8s %-6s %-10s %-10s %-5s %-5s %-4d %-4d %-12s%n",
                     reservation.reservationId,
                     reservation.roomId,
                     cut(roomName, 10),
@@ -369,6 +403,7 @@ final class CliApp {
                     TimeFormats.formatTime(reservation.startTime),
                     TimeFormats.formatTime(reservation.endTime),
                     reservation.partySize,
+                    reservation.extensionCount,
                     reservation.status.name());
         }
         System.out.println("조회가 끝났습니다.");
@@ -419,6 +454,88 @@ final class CliApp {
         System.out.println("체크인이 완료되었습니다.");
     }
 
+    private void handleExtendReservation() throws AppDataException {
+        requireRole(Role.MEMBER);
+        SystemData data = loadAndSync();
+        MemberStanding standing = calculateMemberStanding(data, loggedInUserId);
+        if (!standing.excellent) {
+            System.out.println("오류: 예약 연장은 우수회원만 신청할 수 있습니다.");
+            return;
+        }
+
+        System.out.println("[예약 연장]");
+        System.out.println("현재 가상 시각: " + TimeFormats.formatDateTime(data.currentTime));
+        String reservationId = promptReservationId("연장할 예약번호 입력: ");
+
+        Reservation reservation = data.reservations.get(reservationId);
+        if (reservation == null) {
+            System.out.println("오류: 존재하지 않는 예약번호입니다.");
+            return;
+        }
+        if (!reservation.userId.equals(loggedInUserId)) {
+            System.out.println("오류: 본인의 예약만 연장할 수 있습니다.");
+            return;
+        }
+
+        if (standing.underPenalty(data.currentTime)) {
+            System.out.println("오류: 노쇼 패널티로 "
+                    + TimeFormats.formatDateTime(standing.penaltyUntil)
+                    + " 이후 예약 연장이 가능합니다.");
+            return;
+        }
+        if (reservation.status != ReservationStatus.CHECKED_IN) {
+            System.out.println("오류: CHECKED_IN 상태의 예약만 연장할 수 있습니다.");
+            return;
+        }
+
+        Room room = data.rooms.get(reservation.roomId);
+        if (room == null || room.roomStatus != RoomStatus.OPEN) {
+            System.out.println("오류: 대상 룸이 OPEN 상태가 아니어서 연장할 수 없습니다.");
+            return;
+        }
+
+        LocalDateTime now = data.currentTime;
+        LocalDateTime oldEnd = reservation.endDateTime();
+        if (now.isBefore(oldEnd.minusMinutes(30))) {
+            System.out.println("오류: 예약 종료 30분 전부터 연장할 수 있습니다.");
+            return;
+        }
+        if (!now.isBefore(oldEnd)) {
+            System.out.println("오류: 예약 종료 시각 이후에는 연장할 수 없습니다.");
+            return;
+        }
+        if (reservation.extensionCount >= 3) {
+            System.out.println("오류: 예약당 최대 3회까지만 연장할 수 있습니다.");
+            return;
+        }
+
+        LocalDateTime newEnd = oldEnd.plusHours(1);
+        if (!newEnd.toLocalDate().equals(reservation.date)) {
+            System.out.println("오류: 예약 연장은 같은 날짜 안에서만 가능합니다.");
+            return;
+        }
+        long totalMinutes = Duration.between(reservation.startDateTime(), newEnd).toMinutes();
+        if (totalMinutes > 300) {
+            System.out.println("오류: 연장 후 총 이용 시간은 5시간을 넘을 수 없습니다.");
+            return;
+        }
+        if (hasRoomOverlap(data, reservation.roomId, oldEnd, newEnd, reservation.reservationId)) {
+            System.out.println("오류: 같은 룸의 다음 예약과 충돌하여 연장할 수 없습니다.");
+            return;
+        }
+        if (hasUserOverlap(data, loggedInUserId, oldEnd, newEnd, reservation.reservationId)) {
+            System.out.println("오류: 같은 회원의 다른 예약과 충돌하여 연장할 수 없습니다.");
+            return;
+        }
+
+        String beforeRecord = reservation.toRecord();
+        reservation.endTime = newEnd.toLocalTime();
+        reservation.extensionCount++;
+        store.saveAll(data);
+        printRecordChange("RESV", beforeRecord, reservation.toRecord());
+        System.out.println("예약 시간이 1시간 연장되었습니다.");
+    }
+
     private void handleChangeCurrentTime() throws AppDataException {
         requireLoggedIn();
         SystemData data = loadAndSync();
@@ -450,12 +567,12 @@ final class CliApp {
             return;
         }
 
-        System.out.printf("%-8s %-10s %-10s %-6s %-10s %-5s %-5s %-4s %-12s %-16s%n",
-                "resvId", "userId", "userName", "room", "date", "start", "end", "인원", "status", "checkedInAt");
+        System.out.printf("%-8s %-10s %-10s %-6s %-10s %-5s %-5s %-4s %-4s %-12s %-16s%n",
+                "resvId", "userId", "userName", "room", "date", "start", "end", "인원", "연장", "status", "checkedInAt");
         for (Reservation reservation : data.sortedReservations()) {
             User user = data.users.get(reservation.userId);
             String userName = user == null ? reservation.userId : user.userName;
-            System.out.printf("%-8s %-10s %-10s %-6s %-10s %-5s %-5s %-4d %-12s %-16s%n",
+            System.out.printf("%-8s %-10s %-10s %-6s %-10s %-5s %-5s %-4d %-4d %-12s %-16s%n",
                     reservation.reservationId,
                     reservation.userId,
                     cut(userName, 10),
@@ -464,6 +581,7 @@ final class CliApp {
                     TimeFormats.formatTime(reservation.startTime),
                     TimeFormats.formatTime(reservation.endTime),
                     reservation.partySize,
+                    reservation.extensionCount,
                     reservation.status.name(),
                     reservation.checkedInAtText());
         }
@@ -802,6 +920,44 @@ final class CliApp {
         return false;
     }
 
+    private MemberStanding calculateMemberStanding(SystemData data, String userId) {
+        LocalDateTime now = data.currentTime;
+        int recentNoShowCount = 0;
+        LocalDateTime lastNoShowAt = null;
+        int recentCompletedCount = 0;
+
+        for (Reservation reservation : data.reservations.values()) {
+            if (!reservation.userId.equals(userId)) {
+                continue;
+            }
+            if (reservation.status == ReservationStatus.NO_SHOW) {
+                LocalDateTime noShowAt = reservation.startDateTime().plusMinutes(10);
+                if (isInRecentSevenDays(noShowAt, now)) {
+                    recentNoShowCount++;
+                    if (lastNoShowAt == null || noShowAt.isAfter(lastNoShowAt)) {
+                        lastNoShowAt = noShowAt;
+                    }
+                }
+            } else if (reservation.status == ReservationStatus.COMPLETED) {
+                LocalDateTime completedAt = reservation.endDateTime();
+                if (isInRecentSevenDays(completedAt, now)) {
+                    recentCompletedCount++;
+                }
+            }
+        }
+
+        LocalDateTime penaltyUntil = null;
+        if (lastNoShowAt != null) {
+            penaltyUntil = lastNoShowAt.plusDays(7);
+        }
+        boolean excellent = recentCompletedCount >= 2 && recentNoShowCount == 0;
+        return new MemberStanding(recentNoShowCount, penaltyUntil, excellent);
+    }
+
+    private boolean isInRecentSevenDays(LocalDateTime eventTime, LocalDateTime now) {
+        return eventTime.isAfter(now.minusDays(7)) && !eventTime.isAfter(now);
+    }
+
     private String validateReservationWindow(LocalDate date, LocalTime start, LocalTime end) {
         if (start.getMinute() != 0 || end.getMinute() != 0) {
             return "예약 시각은 1시간 단위여야 합니다.";
@@ -840,8 +996,8 @@ final class CliApp {
     }
 
     private void printMyReservationHeader() {
-        System.out.printf("%-8s %-6s %-10s %-10s %-5s %-5s %-4s %-12s%n",
-                "resvId", "room", "roomName", "date", "start", "end", "인원", "status");
+        System.out.printf("%-8s %-6s %-10s %-10s %-5s %-5s %-4s %-4s %-12s%n",
+                "resvId", "room", "roomName", "date", "start", "end", "인원", "연장", "status");
     }
 
     private String cut(String value, int width) {

--- a/src/main/java/ku/com/Domain.java
+++ b/src/main/java/ku/com/Domain.java
@@ -109,11 +109,12 @@ final class Reservation {
     String roomId;
     final LocalDate date;
     final LocalTime startTime;
-    final LocalTime endTime;
+    LocalTime endTime;
     final BigInteger partySize;
     ReservationStatus status;
     final LocalDateTime createdAt;
     LocalDateTime checkedInAt;
+    int extensionCount;
     final int sourceLine;
 
     Reservation(String reservationId,
@@ -126,6 +127,7 @@ final class Reservation {
                 ReservationStatus status,
                 LocalDateTime createdAt,
                 LocalDateTime checkedInAt,
+                int extensionCount,
                 int sourceLine) {
         this.reservationId = reservationId;
         this.userId = userId;
@@ -137,6 +139,7 @@ final class Reservation {
         this.status = status;
         this.createdAt = createdAt;
         this.checkedInAt = checkedInAt;
+        this.extensionCount = extensionCount;
         this.sourceLine = sourceLine;
     }
 
@@ -172,6 +175,7 @@ final class Reservation {
                 status,
                 createdAt,
                 checkedInAt,
+                extensionCount,
                 sourceLine);
     }
 
@@ -187,7 +191,8 @@ final class Reservation {
                 String.valueOf(partySize),
                 status.name(),
                 TimeFormats.formatDateTime(createdAt),
-                checkedInAtText());
+                checkedInAtText(),
+                String.valueOf(extensionCount));
     }
 }
 
@@ -218,6 +223,9 @@ final class SystemData {
             } catch (NumberFormatException ignored) {
             }
         }
+        if (max >= 9999) {
+            return null;
+        }
         return String.format("rv%04d", max + 1);
     }
 
@@ -231,6 +239,9 @@ final class SystemData {
                 max = Math.max(max, Integer.parseInt(id.substring(4)));
             } catch (NumberFormatException ignored) {
             }
+        }
+        if (max >= 999) {
+            return null;
         }
         return String.format("user%03d", max + 1);
     }

--- a/src/main/java/ku/com/TextDataStore.java
+++ b/src/main/java/ku/com/TextDataStore.java
@@ -89,6 +89,8 @@ final class TextDataStore {
 
             require(USER_ID_PATTERN.matcher(userId).matches(), USERS_FILE, line.lineNumber,
                     "userId 형식이 올바르지 않습니다.");
+            require(Integer.parseInt(userId.substring(4)) >= 1, USERS_FILE, line.lineNumber,
+                    "userId 숫자부는 001 이상이어야 합니다.");
             require(LOGIN_ID_PATTERN.matcher(loginId).matches(), USERS_FILE, line.lineNumber,
                     "loginId 형식이 올바르지 않습니다.");
             require(password.length() >= 4 && password.length() <= 20, USERS_FILE, line.lineNumber,
@@ -135,7 +137,7 @@ final class TextDataStore {
         List<LineRecord> lines = readLogicalLines(reservationsPath, RESERVATIONS_FILE);
         LinkedHashMap<String, Reservation> reservations = new LinkedHashMap<>();
         for (LineRecord line : lines) {
-            String[] fields = splitFields(line, RESERVATIONS_FILE, 11);
+            String[] fields = splitFields(line, RESERVATIONS_FILE, 12);
             require("RESV".equals(fields[0]), RESERVATIONS_FILE, line.lineNumber, "레코드 접두어는 RESV여야 합니다.");
             String reservationId = fields[1].trim();
             String userId = fields[2].trim();
@@ -147,11 +149,16 @@ final class TextDataStore {
             ReservationStatus status = ReservationStatus.fromFile(fields[8], RESERVATIONS_FILE, line.lineNumber);
             LocalDateTime createdAt = TimeFormats.parseDateTime(fields[9], RESERVATIONS_FILE, line.lineNumber, "createdAt");
             String checkedInRaw = fields[10].trim();
+            int extensionCount = parseNonNegativeInt(fields[11], RESERVATIONS_FILE, line.lineNumber, "extensionCount");
 
             require(RESERVATION_ID_PATTERN.matcher(reservationId).matches(), RESERVATIONS_FILE, line.lineNumber,
                     "reservationId 형식이 올바르지 않습니다.");
+            require(Integer.parseInt(reservationId.substring(2)) >= 1, RESERVATIONS_FILE, line.lineNumber,
+                    "reservationId 숫자부는 0001 이상이어야 합니다.");
             require(USER_ID_PATTERN.matcher(userId).matches(), RESERVATIONS_FILE, line.lineNumber,
                     "userId 형식이 올바르지 않습니다.");
+            require(Integer.parseInt(userId.substring(4)) >= 1, RESERVATIONS_FILE, line.lineNumber,
+                    "userId 숫자부는 001 이상이어야 합니다.");
             require(ROOM_ID_PATTERN.matcher(roomId).matches(), RESERVATIONS_FILE, line.lineNumber,
                     "roomId 형식이 올바르지 않습니다.");
             require(partySize.compareTo(BigInteger.ONE) >= 0, RESERVATIONS_FILE, line.lineNumber, "partySize는 1 이상이어야 합니다.");
@@ -161,14 +168,32 @@ final class TextDataStore {
                     "startTime은 endTime보다 빨라야 합니다.");
 
             long minutes = Duration.between(LocalDateTime.of(date, startTime), LocalDateTime.of(date, endTime)).toMinutes();
-            require(minutes == 60 || minutes == 120 || minutes == 180 || minutes == 240,
+            require(minutes == 60 || minutes == 120 || minutes == 180 || minutes == 240 || minutes == 300,
+                    RESERVATIONS_FILE, line.lineNumber, "예약 길이는 1시간 이상 5시간 이하이고 1시간 단위여야 합니다.");
+            require(extensionCount > 0 || minutes <= 240,
                     RESERVATIONS_FILE, line.lineNumber, "예약 길이는 1시간, 2시간, 3시간, 4시간 중 하나여야 합니다.");
+            require(extensionCount == 0
+                            || status == ReservationStatus.CHECKED_IN
+                            || status == ReservationStatus.COMPLETED,
+                    RESERVATIONS_FILE, line.lineNumber,
+                    "extensionCount가 1 이상인 예약은 CHECKED_IN 또는 COMPLETED 상태여야 합니다.");
+            require((status != ReservationStatus.RESERVED && status != ReservationStatus.NO_SHOW) || extensionCount == 0,
+                    RESERVATIONS_FILE, line.lineNumber, "RESERVED/NO_SHOW 상태 예약의 extensionCount는 0이어야 합니다.");
+            require(extensionCount <= 3, RESERVATIONS_FILE, line.lineNumber,
+                    "extensionCount는 3을 초과할 수 없습니다.");
+            require(!createdAt.isAfter(LocalDateTime.of(date, startTime)), RESERVATIONS_FILE, line.lineNumber,
+                    "createdAt은 예약 시작 일시보다 늦을 수 없습니다.");
 
             LocalDateTime checkedInAt = null;
             if (status == ReservationStatus.CHECKED_IN || status == ReservationStatus.COMPLETED) {
                 require(!"-".equals(checkedInRaw), RESERVATIONS_FILE, line.lineNumber,
                         "CHECKED_IN/COMPLETED 상태는 checkedInAt 값이 필요합니다.");
                 checkedInAt = TimeFormats.parseDateTime(checkedInRaw, RESERVATIONS_FILE, line.lineNumber, "checkedInAt");
+                LocalDateTime checkInOpen = LocalDateTime.of(date, startTime).minusMinutes(10);
+                LocalDateTime checkInClose = LocalDateTime.of(date, startTime).plusMinutes(10);
+                require(!checkedInAt.isBefore(checkInOpen) && !checkedInAt.isAfter(checkInClose),
+                        RESERVATIONS_FILE, line.lineNumber,
+                        "checkedInAt은 체크인 가능 구간 안에 있어야 합니다.");
             } else {
                 require("-".equals(checkedInRaw), RESERVATIONS_FILE, line.lineNumber,
                         "RESERVED/NO_SHOW 상태는 checkedInAt이 '-' 이어야 합니다.");
@@ -185,6 +210,7 @@ final class TextDataStore {
                     status,
                     createdAt,
                     checkedInAt,
+                    extensionCount,
                     line.lineNumber));
             require(prev == null, RESERVATIONS_FILE, line.lineNumber, "중복된 reservationId가 존재합니다.");
         }
@@ -223,6 +249,13 @@ final class TextDataStore {
                 require(reservation.partySize.compareTo(room.maxCapacity) <= 0, RESERVATIONS_FILE, reservation.sourceLine,
                         "partySize가 해당 room의 maxCapacity를 초과합니다.");
             }
+            long minutes = Duration.between(reservation.startDateTime(), reservation.endDateTime()).toMinutes();
+            require(minutes <= 300, RESERVATIONS_FILE, reservation.sourceLine,
+                    "예약 길이는 5시간을 초과할 수 없습니다.");
+            require(reservation.extensionCount <= 3, RESERVATIONS_FILE, reservation.sourceLine,
+                    "extensionCount는 3을 초과할 수 없습니다.");
+            require(reservation.extensionCount > 0 || minutes <= 240, RESERVATIONS_FILE, reservation.sourceLine,
+                    "연장되지 않은 예약은 4시간을 초과할 수 없습니다.");
         }
 
         for (int i = 0; i < reservations.size(); i++) {
@@ -289,6 +322,18 @@ final class TextDataStore {
             return new BigInteger(raw.trim());
         } catch (NumberFormatException e) {
             throw new AppDataException(fileName, lineNumber, fieldName + " 값은 정수여야 합니다.");
+        }
+    }
+
+    private int parseNonNegativeInt(String raw, String fileName, int lineNumber, String fieldName) throws AppDataException {
+        try {
+            int value = Integer.parseInt(raw.trim());
+            if (value < 0) {
+                throw new NumberFormatException();
+            }
+            return value;
+        } catch (NumberFormatException e) {
+            throw new AppDataException(fileName, lineNumber, fieldName + " 값은 0 이상의 정수여야 합니다.");
         }
     }
 

--- a/src/test/java/ku/com/RegressionTest.java
+++ b/src/test/java/ku/com/RegressionTest.java
@@ -15,6 +15,29 @@ public class RegressionTest {
         testStartupAutoNoShowTransition();
         testStartupAutoCompletedTransition();
         testNextReservationId();
+        testSignupRejectsUserIdUpperBound();
+        testCreateReservationRejectsReservationIdUpperBound();
+        testCreateReservationWritesExtensionCount();
+        testPenaltyBlocksReservationCreation();
+        testPenaltyBoundaryAllowsReservationCreation();
+        testRecentSevenDaysExcludesExactLowerBoundNoShow();
+        testRecentSevenDaysIncludesAfterLowerBoundNoShow();
+        testRecentSevenDaysExcludesExactLowerBoundCompleted();
+        testRecentSevenDaysIncludesAfterLowerBoundCompleted();
+        testExcellentMemberCanExtendCheckedInReservation();
+        testRegularMemberCannotExtendReservation();
+        testRecentNoShowDisqualifiesExcellentExtension();
+        testOldCompletedReservationsDoNotGrantExcellentExtension();
+        testPenaltyMemberExtendFailsBeforeReservationPrompt();
+        testExtendReservationRejectsRoomOverlap();
+        testExtendReservationRejectsUserOverlap();
+        testExtendReservationRejectsClosedRoom();
+        testExtendReservationAllowsExactlyThirtyMinutesBeforeEnd();
+        testExtendReservationRejectsBeforeThirtyMinuteWindow();
+        testExtendReservationRejectsMaxExtensionCount();
+        testExtendReservationRejectsTotalDurationOverFiveHours();
+        testExtendReservationRejectsCrossDateEnd();
+        testExtendedReservationCompletesAtExtendedEnd();
         testHistoricalCompletedReservationCanExceedCurrentCapacity();
         testSameRoomMoveRejected();
 
@@ -43,7 +66,10 @@ public class RegressionTest {
         testRoomRejectsNonNumericMaxCapacity();
         testDuplicateSystemTimeStopsStartup();
         testInvalidSystemTimeFormatStopsStartup();
+        testReservationRejectsMissingExtensionCount();
         testInvalidReservationIdSyntaxStopsStartup();
+        testInvalidUserIdZeroStopsStartup();
+        testInvalidReservationIdZeroStopsStartup();
         testInvalidReservationUserIdSyntaxStopsStartup();
         testInvalidReservationRoomIdSyntaxStopsStartup();
         testDuplicateReservationIdStopsStartup();
@@ -55,7 +81,10 @@ public class RegressionTest {
         testReservationRejectsStartAfterEndInData();
         testReservationRejectsInvalidDurationInData();
         testInvalidCreatedAtFormatStopsStartup();
+        testReservationRejectsCreatedAtAfterStart();
         testInvalidCheckedInAtFormatStopsStartup();
+        testReservationRejectsCheckedInAtOutsideWindow();
+        testReservationRejectsExtensionCountOverLimit();
         testPasswordRejectsEscapedNewlineStopsStartup();
         testReservationRejectsMissingUserReference();
         testReservationRejectsMissingRoomReference();
@@ -190,7 +219,7 @@ public class RegressionTest {
         writeData(root,
                 users("user011", "pw1234", "bonsu"),
                 "ROOM|R101|A룸|4|OPEN\n",
-                "RESV|rv0001|user011|R101|2026-03-20|11:00|12:00|2|RESERVED|2026-03-19 09:00|-\n",
+                "RESV|rv0001|user011|R101|2026-03-20|11:00|12:00|2|RESERVED|2026-03-19 09:00|-|0\n",
                 "NOW|2026-03-20 11:11\n");
 
         TextDataStore store = new TextDataStore(root);
@@ -209,13 +238,13 @@ public class RegressionTest {
         writeData(root,
                 users("user011", "pw1234", "bonsu"),
                 "ROOM|R101|A룸|4|OPEN\n",
-                "RESV|rv0001|user011|R101|2026-03-20|11:00|12:00|2|RESERVED|2026-03-19 09:00|-\n",
+                "RESV|rv0001|user011|R101|2026-03-20|11:00|12:00|2|RESERVED|2026-03-19 09:00|-|0\n",
                 "NOW|2026-03-20 11:11\n");
 
         String output = runCli(root, lines("0"));
 
         assertContains(output, "프로그램을 종료합니다.");
-        assertFileContains(root, "reservations.txt", "RESV|rv0001|user011|R101|2026-03-20|11:00|12:00|2|NO_SHOW|2026-03-19 09:00|-");
+        assertFileContains(root, "reservations.txt", "RESV|rv0001|user011|R101|2026-03-20|11:00|12:00|2|NO_SHOW|2026-03-19 09:00|-|0");
     }
 
     private static void testStartupAutoCompletedTransition() throws Exception {
@@ -223,13 +252,13 @@ public class RegressionTest {
         writeData(root,
                 users("user011", "pw1234", "bonsu"),
                 "ROOM|R101|A룸|4|OPEN\n",
-                "RESV|rv0001|user011|R101|2026-03-20|09:00|10:00|2|CHECKED_IN|2026-03-20 08:30|2026-03-20 08:55\n",
+                "RESV|rv0001|user011|R101|2026-03-20|09:00|10:00|2|CHECKED_IN|2026-03-20 08:30|2026-03-20 08:55|0\n",
                 "NOW|2026-03-20 10:00\n");
 
         String output = runCli(root, lines("0"));
 
         assertContains(output, "프로그램을 종료합니다.");
-        assertFileContains(root, "reservations.txt", "RESV|rv0001|user011|R101|2026-03-20|09:00|10:00|2|COMPLETED|2026-03-20 08:30|2026-03-20 08:55");
+        assertFileContains(root, "reservations.txt", "RESV|rv0001|user011|R101|2026-03-20|09:00|10:00|2|COMPLETED|2026-03-20 08:30|2026-03-20 08:55|0");
     }
 
     private static void testNextReservationId() throws Exception {
@@ -237,8 +266,8 @@ public class RegressionTest {
         writeData(root,
                 users("user011", "pw1234", "bonsu"),
                 "ROOM|R101|A룸|4|OPEN\n",
-                "RESV|rv0001|user011|R101|2026-03-20|11:00|12:00|2|RESERVED|2026-03-19 09:00|-\n"
-                        + "RESV|rv0003|user011|R101|2026-03-21|11:00|12:00|2|RESERVED|2026-03-19 10:00|-\n",
+                "RESV|rv0001|user011|R101|2026-03-20|11:00|12:00|2|RESERVED|2026-03-19 09:00|-|0\n"
+                        + "RESV|rv0003|user011|R101|2026-03-21|11:00|12:00|2|RESERVED|2026-03-19 10:00|-|0\n",
                 "NOW|2026-03-20 09:00\n");
 
         SystemData dataSet = new TextDataStore(root).loadAll();
@@ -248,12 +277,552 @@ public class RegressionTest {
         }
     }
 
+    private static void testSignupRejectsUserIdUpperBound() throws Exception {
+        Path root = createCliRoot();
+        writeData(root,
+                "USER|user001|admin|admin1234|admin|admin\n"
+                        + "USER|user999|user999|pw1234|lastuser|member\n",
+                baseRooms(),
+                "",
+                "NOW|2026-03-20 09:00\n");
+
+        String output = runCli(root, lines(
+                "1",
+                "newuser",
+                "pass1234",
+                "newuser",
+                "0"));
+
+        assertContains(output, "오류: 더 이상 회원을 추가할 수 없습니다.");
+        assertFileNotContains(root, "users.txt", "newuser");
+    }
+
+    private static void testCreateReservationRejectsReservationIdUpperBound() throws Exception {
+        Path root = createCliRoot();
+        writeData(root,
+                baseUsers(),
+                baseRooms(),
+                "RESV|rv9999|user022|R101|2026-03-20|10:00|11:00|2|RESERVED|2026-03-20 09:00|-|0\n",
+                "NOW|2026-03-20 09:00\n");
+
+        String output = runCli(root, lines(
+                "2",
+                "user011",
+                "pw1234",
+                "3",
+                "2026-03-20",
+                "15:00",
+                "16:00",
+                "2",
+                "R102",
+                "0",
+                "0"));
+
+        assertContains(output, "오류: 더 이상 예약을 추가할 수 없습니다.");
+        assertFileNotContains(root, "reservations.txt", "rv10000");
+    }
+
+    private static void testCreateReservationWritesExtensionCount() throws Exception {
+        Path root = createCliRoot();
+        writeData(root, baseUsers(), baseRooms(), "", "NOW|2026-03-20 09:00\n");
+
+        String output = runCli(root, lines(
+                "2",
+                "user011",
+                "pw1234",
+                "3",
+                "2026-03-20",
+                "13:00",
+                "14:00",
+                "2",
+                "R101",
+                "0",
+                "0"));
+
+        assertContains(output, "예약이 완료되었습니다.");
+        assertFileContains(root, "reservations.txt",
+                "RESV|rv0001|user011|R101|2026-03-20|13:00|14:00|2|RESERVED|2026-03-20 09:00|-|0");
+    }
+
+    private static void testPenaltyBlocksReservationCreation() throws Exception {
+        Path root = createCliRoot();
+        writeData(root,
+                baseUsers(),
+                baseRooms(),
+                "RESV|rv0001|user011|R101|2026-03-20|10:00|11:00|2|NO_SHOW|2026-03-20 09:00|-|0\n",
+                "NOW|2026-03-20 11:30\n");
+
+        String output = runCli(root, lines(
+                "2",
+                "user011",
+                "pw1234",
+                "3",
+                "2026-03-20",
+                "15:00",
+                "16:00",
+                "2",
+                "R102",
+                "0",
+                "0"));
+
+        assertContains(output, "패널티 상태: 패널티 대상");
+        assertContains(output, "패널티 해제 시각: 2026-03-27 10:10");
+        assertContains(output, "오류: 노쇼 패널티로 2026-03-27 10:10 이후 예약 신청이 가능합니다.");
+        assertFileNotContains(root, "reservations.txt", "rv0002");
+    }
+
+    private static void testPenaltyBoundaryAllowsReservationCreation() throws Exception {
+        Path root = createCliRoot();
+        writeData(root,
+                baseUsers(),
+                baseRooms(),
+                "RESV|rv0001|user011|R101|2026-03-20|10:00|11:00|2|NO_SHOW|2026-03-20 09:00|-|0\n",
+                "NOW|2026-03-27 10:10\n");
+
+        runCli(root, lines(
+                "2",
+                "user011",
+                "pw1234",
+                "3",
+                "2026-03-27",
+                "15:00",
+                "16:00",
+                "2",
+                "R102",
+                "0",
+                "0"));
+
+        assertFileContains(root, "reservations.txt",
+                "RESV|rv0002|user011|R102|2026-03-27|15:00|16:00|2|RESERVED|2026-03-27 10:10|-|0");
+    }
+
+    private static void testRecentSevenDaysExcludesExactLowerBoundNoShow() throws Exception {
+        Path root = createCliRoot();
+        writeData(root,
+                baseUsers(),
+                baseRooms(),
+                "RESV|rv0001|user011|R101|2026-03-20|10:00|11:00|2|NO_SHOW|2026-03-20 09:00|-|0\n",
+                "NOW|2026-03-27 10:10\n");
+
+        String output = runCli(root, lines(
+                "2",
+                "user011",
+                "pw1234",
+                "0",
+                "0"));
+
+        assertContains(output, "패널티 상태: 없음");
+    }
+
+    private static void testRecentSevenDaysIncludesAfterLowerBoundNoShow() throws Exception {
+        Path root = createCliRoot();
+        writeData(root,
+                baseUsers(),
+                baseRooms(),
+                "RESV|rv0001|user011|R101|2026-03-20|11:00|12:00|2|NO_SHOW|2026-03-20 09:00|-|0\n",
+                "NOW|2026-03-27 10:10\n");
+
+        String output = runCli(root, lines(
+                "2",
+                "user011",
+                "pw1234",
+                "0",
+                "0"));
+
+        assertContains(output, "패널티 상태: 패널티 대상");
+        assertContains(output, "패널티 해제 시각: 2026-03-27 11:10");
+    }
+
+    private static void testRecentSevenDaysExcludesExactLowerBoundCompleted() throws Exception {
+        Path root = createCliRoot();
+        writeData(root,
+                baseUsers(),
+                baseRooms(),
+                "RESV|rv0001|user011|R102|2026-03-20|09:00|10:00|2|COMPLETED|2026-03-20 08:00|2026-03-20 08:55|0\n"
+                        + "RESV|rv0002|user011|R103|2026-03-21|09:00|10:00|2|COMPLETED|2026-03-21 08:00|2026-03-21 08:55|0\n"
+                        + "RESV|rv0003|user011|R101|2026-03-27|09:00|11:00|2|CHECKED_IN|2026-03-27 08:00|2026-03-27 08:55|0\n",
+                "NOW|2026-03-27 10:00\n");
+
+        String output = runCli(root, lines(
+                "2",
+                "user011",
+                "pw1234",
+                "7",
+                "0",
+                "0"));
+
+        assertContains(output, "회원 상태: 일반회원");
+        assertContains(output, "오류: 예약 연장은 우수회원만 신청할 수 있습니다.");
+        assertNotContains(output, "연장할 예약번호 입력");
+        assertFileContains(root, "reservations.txt",
+                "RESV|rv0003|user011|R101|2026-03-27|09:00|11:00|2|CHECKED_IN|2026-03-27 08:00|2026-03-27 08:55|0");
+    }
+
+    private static void testRecentSevenDaysIncludesAfterLowerBoundCompleted() throws Exception {
+        Path root = createCliRoot();
+        writeData(root,
+                baseUsers(),
+                baseRooms(),
+                "RESV|rv0001|user011|R102|2026-03-20|10:00|11:00|2|COMPLETED|2026-03-20 08:00|2026-03-20 09:55|0\n"
+                        + "RESV|rv0002|user011|R103|2026-03-21|09:00|10:00|2|COMPLETED|2026-03-21 08:00|2026-03-21 08:55|0\n"
+                        + "RESV|rv0003|user011|R101|2026-03-27|09:00|11:00|2|CHECKED_IN|2026-03-27 08:00|2026-03-27 08:55|0\n",
+                "NOW|2026-03-27 10:35\n");
+
+        runCli(root, lines(
+                "2",
+                "user011",
+                "pw1234",
+                "7",
+                "rv0003",
+                "0",
+                "0"));
+
+        assertFileContains(root, "reservations.txt",
+                "RESV|rv0003|user011|R101|2026-03-27|09:00|12:00|2|CHECKED_IN|2026-03-27 08:00|2026-03-27 08:55|1");
+    }
+
+    private static void testExcellentMemberCanExtendCheckedInReservation() throws Exception {
+        Path root = createCliRoot();
+        writeData(root,
+                baseUsers(),
+                baseRooms(),
+                "RESV|rv0001|user011|R102|2026-03-18|09:00|10:00|2|COMPLETED|2026-03-18 08:00|2026-03-18 08:55|0\n"
+                        + "RESV|rv0002|user011|R103|2026-03-19|09:00|10:00|2|COMPLETED|2026-03-19 08:00|2026-03-19 08:55|0\n"
+                        + "RESV|rv0003|user011|R101|2026-03-20|13:00|15:00|2|CHECKED_IN|2026-03-20 09:00|2026-03-20 12:55|0\n",
+                "NOW|2026-03-20 14:35\n");
+
+        String output = runCli(root, lines(
+                "2",
+                "user011",
+                "pw1234",
+                "7",
+                "rv0003",
+                "0",
+                "0"));
+
+        assertContains(output, "회원 상태: 우수회원");
+        assertContains(output, "예약 시간이 1시간 연장되었습니다.");
+        assertFileContains(root, "reservations.txt",
+                "RESV|rv0003|user011|R101|2026-03-20|13:00|16:00|2|CHECKED_IN|2026-03-20 09:00|2026-03-20 12:55|1");
+    }
+
+    private static void testRegularMemberCannotExtendReservation() throws Exception {
+        Path root = createCliRoot();
+        writeData(root,
+                baseUsers(),
+                baseRooms(),
+                "RESV|rv0001|user011|R101|2026-03-20|13:00|15:00|2|CHECKED_IN|2026-03-20 09:00|2026-03-20 12:55|0\n",
+                "NOW|2026-03-20 14:35\n");
+
+        String output = runCli(root, lines(
+                "2",
+                "user011",
+                "pw1234",
+                "7",
+                "0",
+                "0"));
+
+        assertContains(output, "회원 상태: 일반회원");
+        assertContains(output, "오류: 예약 연장은 우수회원만 신청할 수 있습니다.");
+        assertNotContains(output, "연장할 예약번호 입력");
+        assertFileContains(root, "reservations.txt",
+                "RESV|rv0001|user011|R101|2026-03-20|13:00|15:00|2|CHECKED_IN|2026-03-20 09:00|2026-03-20 12:55|0");
+    }
+
+    private static void testRecentNoShowDisqualifiesExcellentExtension() throws Exception {
+        Path root = createCliRoot();
+        writeData(root,
+                baseUsers(),
+                baseRooms(),
+                "RESV|rv0001|user011|R102|2026-03-18|09:00|10:00|2|COMPLETED|2026-03-18 08:00|2026-03-18 08:55|0\n"
+                        + "RESV|rv0002|user011|R103|2026-03-19|09:00|10:00|2|COMPLETED|2026-03-19 08:00|2026-03-19 08:55|0\n"
+                        + "RESV|rv0003|user011|R102|2026-03-20|10:00|11:00|2|NO_SHOW|2026-03-20 08:00|-|0\n"
+                        + "RESV|rv0004|user011|R101|2026-03-20|13:00|15:00|2|CHECKED_IN|2026-03-20 09:00|2026-03-20 12:55|0\n",
+                "NOW|2026-03-20 14:35\n");
+
+        String output = runCli(root, lines(
+                "2",
+                "user011",
+                "pw1234",
+                "7",
+                "0",
+                "0"));
+
+        assertContains(output, "오류: 예약 연장은 우수회원만 신청할 수 있습니다.");
+        assertNotContains(output, "연장할 예약번호 입력");
+        assertFileContains(root, "reservations.txt",
+                "RESV|rv0004|user011|R101|2026-03-20|13:00|15:00|2|CHECKED_IN|2026-03-20 09:00|2026-03-20 12:55|0");
+    }
+
+    private static void testOldCompletedReservationsDoNotGrantExcellentExtension() throws Exception {
+        Path root = createCliRoot();
+        writeData(root,
+                baseUsers(),
+                baseRooms(),
+                "RESV|rv0001|user011|R102|2026-03-13|11:00|12:00|2|COMPLETED|2026-03-13 08:00|2026-03-13 10:55|0\n"
+                        + "RESV|rv0002|user011|R103|2026-03-13|13:00|14:00|2|COMPLETED|2026-03-13 08:00|2026-03-13 12:55|0\n"
+                        + "RESV|rv0003|user011|R101|2026-03-20|13:00|15:00|2|CHECKED_IN|2026-03-20 09:00|2026-03-20 12:55|0\n",
+                "NOW|2026-03-20 14:35\n");
+
+        String output = runCli(root, lines(
+                "2",
+                "user011",
+                "pw1234",
+                "7",
+                "0",
+                "0"));
+
+        assertContains(output, "오류: 예약 연장은 우수회원만 신청할 수 있습니다.");
+        assertNotContains(output, "연장할 예약번호 입력");
+        assertFileContains(root, "reservations.txt",
+                "RESV|rv0003|user011|R101|2026-03-20|13:00|15:00|2|CHECKED_IN|2026-03-20 09:00|2026-03-20 12:55|0");
+    }
+
+    private static void testPenaltyMemberExtendFailsBeforeReservationPrompt() throws Exception {
+        Path root = createCliRoot();
+        writeData(root,
+                baseUsers(),
+                baseRooms(),
+                "RESV|rv0001|user011|R102|2026-03-18|09:00|10:00|2|COMPLETED|2026-03-18 08:00|2026-03-18 08:55|0\n"
+                        + "RESV|rv0002|user011|R103|2026-03-19|09:00|10:00|2|COMPLETED|2026-03-19 08:00|2026-03-19 08:55|0\n"
+                        + "RESV|rv0003|user011|R102|2026-03-20|10:00|11:00|2|NO_SHOW|2026-03-20 08:00|-|0\n"
+                        + "RESV|rv0004|user011|R101|2026-03-20|13:00|15:00|2|CHECKED_IN|2026-03-20 09:00|2026-03-20 12:55|0\n",
+                "NOW|2026-03-20 14:35\n");
+
+        String output = runCli(root, lines(
+                "2",
+                "user011",
+                "pw1234",
+                "7",
+                "0",
+                "0"));
+
+        assertContains(output, "패널티 상태: 패널티 대상");
+        assertContains(output, "오류: 예약 연장은 우수회원만 신청할 수 있습니다.");
+        assertNotContains(output, "연장할 예약번호 입력");
+    }
+
+    private static void testExtendReservationRejectsRoomOverlap() throws Exception {
+        Path root = createCliRoot();
+        writeData(root,
+                baseUsers(),
+                baseRooms(),
+                "RESV|rv0001|user011|R102|2026-03-18|09:00|10:00|2|COMPLETED|2026-03-18 08:00|2026-03-18 08:55|0\n"
+                        + "RESV|rv0002|user011|R103|2026-03-19|09:00|10:00|2|COMPLETED|2026-03-19 08:00|2026-03-19 08:55|0\n"
+                        + "RESV|rv0003|user011|R101|2026-03-20|13:00|15:00|2|CHECKED_IN|2026-03-20 09:00|2026-03-20 12:55|0\n"
+                        + "RESV|rv0004|user022|R101|2026-03-20|15:30|16:30|2|RESERVED|2026-03-20 09:00|-|0\n",
+                "NOW|2026-03-20 14:35\n");
+
+        runCli(root, lines(
+                "2",
+                "user011",
+                "pw1234",
+                "7",
+                "rv0003",
+                "0",
+                "0"));
+
+        assertFileContains(root, "reservations.txt",
+                "RESV|rv0003|user011|R101|2026-03-20|13:00|15:00|2|CHECKED_IN|2026-03-20 09:00|2026-03-20 12:55|0");
+    }
+
+    private static void testExtendReservationRejectsUserOverlap() throws Exception {
+        Path root = createCliRoot();
+        writeData(root,
+                baseUsers(),
+                baseRooms(),
+                "RESV|rv0001|user011|R102|2026-03-18|09:00|10:00|2|COMPLETED|2026-03-18 08:00|2026-03-18 08:55|0\n"
+                        + "RESV|rv0002|user011|R103|2026-03-19|09:00|10:00|2|COMPLETED|2026-03-19 08:00|2026-03-19 08:55|0\n"
+                        + "RESV|rv0003|user011|R101|2026-03-20|13:00|15:00|2|CHECKED_IN|2026-03-20 09:00|2026-03-20 12:55|0\n"
+                        + "RESV|rv0004|user011|R102|2026-03-20|15:30|16:30|2|RESERVED|2026-03-20 09:00|-|0\n",
+                "NOW|2026-03-20 14:35\n");
+
+        runCli(root, lines(
+                "2",
+                "user011",
+                "pw1234",
+                "7",
+                "rv0003",
+                "0",
+                "0"));
+
+        assertFileContains(root, "reservations.txt",
+                "RESV|rv0003|user011|R101|2026-03-20|13:00|15:00|2|CHECKED_IN|2026-03-20 09:00|2026-03-20 12:55|0");
+    }
+
+    private static void testExtendReservationRejectsClosedRoom() throws Exception {
+        Path root = createCliRoot();
+        writeData(root,
+                baseUsers(),
+                "ROOM|R101|A룸|4|CLOSED\n"
+                        + "ROOM|R102|B룸|6|OPEN\n"
+                        + "ROOM|R103|C룸|8|OPEN\n",
+                "RESV|rv0001|user011|R102|2026-03-18|09:00|10:00|2|COMPLETED|2026-03-18 08:00|2026-03-18 08:55|0\n"
+                        + "RESV|rv0002|user011|R103|2026-03-19|09:00|10:00|2|COMPLETED|2026-03-19 08:00|2026-03-19 08:55|0\n"
+                        + "RESV|rv0003|user011|R101|2026-03-20|13:00|15:00|2|CHECKED_IN|2026-03-20 09:00|2026-03-20 12:55|0\n",
+                "NOW|2026-03-20 14:35\n");
+
+        runCli(root, lines(
+                "2",
+                "user011",
+                "pw1234",
+                "7",
+                "rv0003",
+                "0",
+                "0"));
+
+        assertFileContains(root, "reservations.txt",
+                "RESV|rv0003|user011|R101|2026-03-20|13:00|15:00|2|CHECKED_IN|2026-03-20 09:00|2026-03-20 12:55|0");
+    }
+
+    private static void testExtendReservationAllowsExactlyThirtyMinutesBeforeEnd() throws Exception {
+        Path root = createCliRoot();
+        writeData(root,
+                baseUsers(),
+                baseRooms(),
+                "RESV|rv0001|user011|R102|2026-03-18|09:00|10:00|2|COMPLETED|2026-03-18 08:00|2026-03-18 08:55|0\n"
+                        + "RESV|rv0002|user011|R103|2026-03-19|09:00|10:00|2|COMPLETED|2026-03-19 08:00|2026-03-19 08:55|0\n"
+                        + "RESV|rv0003|user011|R101|2026-03-20|13:00|15:00|2|CHECKED_IN|2026-03-20 09:00|2026-03-20 12:55|0\n",
+                "NOW|2026-03-20 14:30\n");
+
+        runCli(root, lines(
+                "2",
+                "user011",
+                "pw1234",
+                "7",
+                "rv0003",
+                "0",
+                "0"));
+
+        assertFileContains(root, "reservations.txt",
+                "RESV|rv0003|user011|R101|2026-03-20|13:00|16:00|2|CHECKED_IN|2026-03-20 09:00|2026-03-20 12:55|1");
+    }
+
+    private static void testExtendReservationRejectsBeforeThirtyMinuteWindow() throws Exception {
+        Path root = createCliRoot();
+        writeData(root,
+                baseUsers(),
+                baseRooms(),
+                "RESV|rv0001|user011|R102|2026-03-18|09:00|10:00|2|COMPLETED|2026-03-18 08:00|2026-03-18 08:55|0\n"
+                        + "RESV|rv0002|user011|R103|2026-03-19|09:00|10:00|2|COMPLETED|2026-03-19 08:00|2026-03-19 08:55|0\n"
+                        + "RESV|rv0003|user011|R101|2026-03-20|13:00|15:00|2|CHECKED_IN|2026-03-20 09:00|2026-03-20 12:55|0\n",
+                "NOW|2026-03-20 14:29\n");
+
+        runCli(root, lines(
+                "2",
+                "user011",
+                "pw1234",
+                "7",
+                "rv0003",
+                "0",
+                "0"));
+
+        assertFileContains(root, "reservations.txt",
+                "RESV|rv0003|user011|R101|2026-03-20|13:00|15:00|2|CHECKED_IN|2026-03-20 09:00|2026-03-20 12:55|0");
+    }
+
+    private static void testExtendReservationRejectsMaxExtensionCount() throws Exception {
+        Path root = createCliRoot();
+        writeData(root,
+                baseUsers(),
+                baseRooms(),
+                "RESV|rv0001|user011|R102|2026-03-18|09:00|10:00|2|COMPLETED|2026-03-18 08:00|2026-03-18 08:55|0\n"
+                        + "RESV|rv0002|user011|R103|2026-03-19|09:00|10:00|2|COMPLETED|2026-03-19 08:00|2026-03-19 08:55|0\n"
+                        + "RESV|rv0003|user011|R101|2026-03-20|13:00|15:00|2|CHECKED_IN|2026-03-20 09:00|2026-03-20 12:55|3\n",
+                "NOW|2026-03-20 14:35\n");
+
+        runCli(root, lines(
+                "2",
+                "user011",
+                "pw1234",
+                "7",
+                "rv0003",
+                "0",
+                "0"));
+
+        assertFileContains(root, "reservations.txt",
+                "RESV|rv0003|user011|R101|2026-03-20|13:00|15:00|2|CHECKED_IN|2026-03-20 09:00|2026-03-20 12:55|3");
+    }
+
+    private static void testExtendReservationRejectsTotalDurationOverFiveHours() throws Exception {
+        Path root = createCliRoot();
+        writeData(root,
+                baseUsers(),
+                baseRooms(),
+                "RESV|rv0001|user011|R102|2026-03-18|09:00|10:00|2|COMPLETED|2026-03-18 08:00|2026-03-18 08:55|0\n"
+                        + "RESV|rv0002|user011|R103|2026-03-19|09:00|10:00|2|COMPLETED|2026-03-19 08:00|2026-03-19 08:55|0\n"
+                        + "RESV|rv0003|user011|R101|2026-03-20|10:00|15:00|2|CHECKED_IN|2026-03-20 09:00|2026-03-20 09:55|1\n",
+                "NOW|2026-03-20 14:35\n");
+
+        runCli(root, lines(
+                "2",
+                "user011",
+                "pw1234",
+                "7",
+                "rv0003",
+                "0",
+                "0"));
+
+        assertFileContains(root, "reservations.txt",
+                "RESV|rv0003|user011|R101|2026-03-20|10:00|15:00|2|CHECKED_IN|2026-03-20 09:00|2026-03-20 09:55|1");
+    }
+
+    private static void testExtendReservationRejectsCrossDateEnd() throws Exception {
+        Path root = createCliRoot();
+        writeData(root,
+                baseUsers(),
+                baseRooms(),
+                "RESV|rv0001|user011|R102|2026-03-18|09:00|10:00|2|COMPLETED|2026-03-18 08:00|2026-03-18 08:55|0\n"
+                        + "RESV|rv0002|user011|R103|2026-03-19|09:00|10:00|2|COMPLETED|2026-03-19 08:00|2026-03-19 08:55|0\n"
+                        + "RESV|rv0003|user011|R101|2026-03-20|20:00|23:00|2|CHECKED_IN|2026-03-20 19:00|2026-03-20 19:55|0\n",
+                "NOW|2026-03-20 22:35\n");
+
+        runCli(root, lines(
+                "2",
+                "user011",
+                "pw1234",
+                "7",
+                "rv0003",
+                "0",
+                "0"));
+
+        assertFileContains(root, "reservations.txt",
+                "RESV|rv0003|user011|R101|2026-03-20|20:00|23:00|2|CHECKED_IN|2026-03-20 19:00|2026-03-20 19:55|0");
+    }
+
+    private static void testExtendedReservationCompletesAtExtendedEnd() throws Exception {
+        Path root = createCliRoot();
+        writeData(root,
+                baseUsers(),
+                baseRooms(),
+                "RESV|rv0001|user011|R101|2026-03-20|13:00|16:00|2|CHECKED_IN|2026-03-20 09:00|2026-03-20 12:55|1\n",
+                "NOW|2026-03-20 15:30\n");
+
+        SystemData beforeEnd = new TextDataStore(root).loadAll();
+        AutoStateUpdater.apply(beforeEnd);
+        if (beforeEnd.reservations.get("rv0001").status != ReservationStatus.CHECKED_IN) {
+            throw new AssertionError("Extended reservation completed before extended end time.");
+        }
+
+        writeData(root,
+                baseUsers(),
+                baseRooms(),
+                "RESV|rv0001|user011|R101|2026-03-20|13:00|16:00|2|CHECKED_IN|2026-03-20 09:00|2026-03-20 12:55|1\n",
+                "NOW|2026-03-20 16:00\n");
+
+        SystemData atEnd = new TextDataStore(root).loadAll();
+        AutoStateUpdater.apply(atEnd);
+        if (atEnd.reservations.get("rv0001").status != ReservationStatus.COMPLETED) {
+            throw new AssertionError("Extended reservation was not completed at extended end time.");
+        }
+    }
+
     private static void testHistoricalCompletedReservationCanExceedCurrentCapacity() throws Exception {
         Path root = Files.createTempDirectory("study-room-capacity-test-");
         writeData(root,
                 users("user011", "pw1234", "bonsu"),
                 "ROOM|R101|A룸|4|OPEN\n",
-                "RESV|rv0001|user011|R101|2026-03-20|11:00|12:00|6|COMPLETED|2026-03-19 09:00|2026-03-20 10:55\n",
+                "RESV|rv0001|user011|R101|2026-03-20|11:00|12:00|6|COMPLETED|2026-03-19 09:00|2026-03-20 10:55|0\n",
                 "NOW|2026-03-20 13:00\n");
 
         SystemData dataSet = new TextDataStore(root).loadAll();
@@ -268,7 +837,7 @@ public class RegressionTest {
                 users("user011", "pw1234", "bonsu"),
                 "ROOM|R101|A룸|4|OPEN\n"
                         + "ROOM|R102|B룸|6|OPEN\n",
-                "RESV|rv0001|user011|R101|2026-03-21|11:00|12:00|2|RESERVED|2026-03-20 09:00|-\n",
+                "RESV|rv0001|user011|R101|2026-03-21|11:00|12:00|2|RESERVED|2026-03-20 09:00|-|0\n",
                 "NOW|2026-03-20 09:00\n");
 
         SystemData dataSet = new TextDataStore(root).loadAll();
@@ -572,16 +1141,53 @@ public class RegressionTest {
         assertContains(output, "[파일 오류] system_time.txt 1행: NOW 형식이 올바르지 않습니다.");
     }
 
+    private static void testReservationRejectsMissingExtensionCount() throws Exception {
+        Path root = createCliRoot();
+        writeData(root,
+                baseUsers(),
+                baseRooms(),
+                "RESV|rv0001|user011|R101|2026-03-20|13:00|14:00|2|RESERVED|2026-03-20 09:00|-\n",
+                "NOW|2026-03-20 09:00\n");
+
+        String output = runCli(root, "");
+        assertContains(output, "[파일 오류] reservations.txt 1행: 필드 개수가 올바르지 않습니다.");
+    }
+
     private static void testInvalidReservationIdSyntaxStopsStartup() throws Exception {
         Path root = createCliRoot();
         writeData(root,
                 baseUsers(),
                 baseRooms(),
-                "RESV|reservation1|user011|R101|2026-03-20|13:00|14:00|2|RESERVED|2026-03-20 09:00|-\n",
+                "RESV|reservation1|user011|R101|2026-03-20|13:00|14:00|2|RESERVED|2026-03-20 09:00|-|0\n",
                 "NOW|2026-03-20 09:00\n");
 
         String output = runCli(root, "");
         assertContains(output, "[파일 오류] reservations.txt 1행: reservationId 형식이 올바르지 않습니다.");
+    }
+
+    private static void testInvalidUserIdZeroStopsStartup() throws Exception {
+        Path root = createCliRoot();
+        writeData(root,
+                "USER|user001|admin|admin1234|admin|admin\n"
+                        + "USER|user000|user000|pw1234|zeroUser|member\n",
+                baseRooms(),
+                "",
+                "NOW|2026-03-20 09:00\n");
+
+        String output = runCli(root, "");
+        assertContains(output, "[파일 오류] users.txt 2행: userId 숫자부는 001 이상이어야 합니다.");
+    }
+
+    private static void testInvalidReservationIdZeroStopsStartup() throws Exception {
+        Path root = createCliRoot();
+        writeData(root,
+                baseUsers(),
+                baseRooms(),
+                "RESV|rv0000|user011|R101|2026-03-20|13:00|14:00|2|RESERVED|2026-03-20 09:00|-|0\n",
+                "NOW|2026-03-20 09:00\n");
+
+        String output = runCli(root, "");
+        assertContains(output, "[파일 오류] reservations.txt 1행: reservationId 숫자부는 0001 이상이어야 합니다.");
     }
 
     private static void testInvalidReservationUserIdSyntaxStopsStartup() throws Exception {
@@ -589,7 +1195,7 @@ public class RegressionTest {
         writeData(root,
                 baseUsers(),
                 baseRooms(),
-                "RESV|rv0001|user 011|R101|2026-03-20|13:00|14:00|2|RESERVED|2026-03-20 09:00|-\n",
+                "RESV|rv0001|user 011|R101|2026-03-20|13:00|14:00|2|RESERVED|2026-03-20 09:00|-|0\n",
                 "NOW|2026-03-20 09:00\n");
 
         String output = runCli(root, "");
@@ -601,7 +1207,7 @@ public class RegressionTest {
         writeData(root,
                 baseUsers(),
                 baseRooms(),
-                "RESV|rv0001|user011|R1 01|2026-03-20|13:00|14:00|2|RESERVED|2026-03-20 09:00|-\n",
+                "RESV|rv0001|user011|R1 01|2026-03-20|13:00|14:00|2|RESERVED|2026-03-20 09:00|-|0\n",
                 "NOW|2026-03-20 09:00\n");
 
         String output = runCli(root, "");
@@ -613,8 +1219,8 @@ public class RegressionTest {
         writeData(root,
                 baseUsers(),
                 baseRooms(),
-                "RESV|rv0001|user011|R101|2026-03-20|13:00|14:00|2|RESERVED|2026-03-20 09:00|-\n"
-                        + "RESV|rv0001|user022|R102|2026-03-20|15:00|16:00|2|RESERVED|2026-03-20 09:10|-\n",
+                "RESV|rv0001|user011|R101|2026-03-20|13:00|14:00|2|RESERVED|2026-03-20 09:00|-|0\n"
+                        + "RESV|rv0001|user022|R102|2026-03-20|15:00|16:00|2|RESERVED|2026-03-20 09:10|-|0\n",
                 "NOW|2026-03-20 09:00\n");
 
         String output = runCli(root, "");
@@ -626,7 +1232,7 @@ public class RegressionTest {
         writeData(root,
                 baseUsers(),
                 baseRooms(),
-                "RESV|rv0001|user011|R101|2026-03-20|13:00|14:00|2|INVALID|2026-03-20 09:00|-\n",
+                "RESV|rv0001|user011|R101|2026-03-20|13:00|14:00|2|INVALID|2026-03-20 09:00|-|0\n",
                 "NOW|2026-03-20 09:00\n");
 
         String output = runCli(root, "");
@@ -638,7 +1244,7 @@ public class RegressionTest {
         writeData(root,
                 baseUsers(),
                 baseRooms(),
-                "RESV|rv0001|user011|R101|2026-02-30|13:00|14:00|2|RESERVED|2026-03-20 09:00|-\n",
+                "RESV|rv0001|user011|R101|2026-02-30|13:00|14:00|2|RESERVED|2026-03-20 09:00|-|0\n",
                 "NOW|2026-03-20 09:00\n");
 
         String output = runCli(root, "");
@@ -650,7 +1256,7 @@ public class RegressionTest {
         writeData(root,
                 baseUsers(),
                 baseRooms(),
-                "RESV|rv0001|user011|R101|2026-03-20|13-00|14:00|2|RESERVED|2026-03-20 09:00|-\n",
+                "RESV|rv0001|user011|R101|2026-03-20|13-00|14:00|2|RESERVED|2026-03-20 09:00|-|0\n",
                 "NOW|2026-03-20 09:00\n");
 
         String output = runCli(root, "");
@@ -662,7 +1268,7 @@ public class RegressionTest {
         writeData(root,
                 baseUsers(),
                 baseRooms(),
-                "RESV|rv0001|user011|R101|2026-03-20|13:00|14-00|2|RESERVED|2026-03-20 09:00|-\n",
+                "RESV|rv0001|user011|R101|2026-03-20|13:00|14-00|2|RESERVED|2026-03-20 09:00|-|0\n",
                 "NOW|2026-03-20 09:00\n");
 
         String output = runCli(root, "");
@@ -674,7 +1280,7 @@ public class RegressionTest {
         writeData(root,
                 baseUsers(),
                 baseRooms(),
-                "RESV|rv0001|user011|R101|2026-03-20|13:00|14:00|0|RESERVED|2026-03-20 09:00|-\n",
+                "RESV|rv0001|user011|R101|2026-03-20|13:00|14:00|0|RESERVED|2026-03-20 09:00|-|0\n",
                 "NOW|2026-03-20 09:00\n");
 
         String output = runCli(root, "");
@@ -686,7 +1292,7 @@ public class RegressionTest {
         writeData(root,
                 baseUsers(),
                 baseRooms(),
-                "RESV|rv0001|user011|R101|2026-03-20|15:00|13:00|2|RESERVED|2026-03-20 09:00|-\n",
+                "RESV|rv0001|user011|R101|2026-03-20|15:00|13:00|2|RESERVED|2026-03-20 09:00|-|0\n",
                 "NOW|2026-03-20 09:00\n");
 
         String output = runCli(root, "");
@@ -698,7 +1304,7 @@ public class RegressionTest {
         writeData(root,
                 baseUsers(),
                 baseRooms(),
-                "RESV|rv0001|user011|R101|2026-03-20|13:00|18:00|2|RESERVED|2026-03-20 09:00|-\n",
+                "RESV|rv0001|user011|R101|2026-03-20|13:00|18:00|2|RESERVED|2026-03-20 09:00|-|0\n",
                 "NOW|2026-03-20 09:00\n");
 
         String output = runCli(root, "");
@@ -710,11 +1316,23 @@ public class RegressionTest {
         writeData(root,
                 baseUsers(),
                 baseRooms(),
-                "RESV|rv0001|user011|R101|2026-03-20|13:00|14:00|2|RESERVED|2026/03/20 09:00|-\n",
+                "RESV|rv0001|user011|R101|2026-03-20|13:00|14:00|2|RESERVED|2026/03/20 09:00|-|0\n",
                 "NOW|2026-03-20 09:00\n");
 
         String output = runCli(root, "");
         assertContains(output, "[파일 오류] reservations.txt 1행: createdAt 형식이 올바르지 않습니다.");
+    }
+
+    private static void testReservationRejectsCreatedAtAfterStart() throws Exception {
+        Path root = createCliRoot();
+        writeData(root,
+                baseUsers(),
+                baseRooms(),
+                "RESV|rv0001|user011|R101|2026-03-20|13:00|14:00|2|RESERVED|2026-03-20 13:01|-|0\n",
+                "NOW|2026-03-20 09:00\n");
+
+        String output = runCli(root, "");
+        assertContains(output, "[파일 오류] reservations.txt 1행: createdAt은 예약 시작 일시보다 늦을 수 없습니다.");
     }
 
     private static void testInvalidCheckedInAtFormatStopsStartup() throws Exception {
@@ -722,11 +1340,35 @@ public class RegressionTest {
         writeData(root,
                 baseUsers(),
                 baseRooms(),
-                "RESV|rv0001|user011|R101|2026-03-20|13:00|14:00|2|CHECKED_IN|2026-03-20 09:00|2026/03/20 12:55\n",
+                "RESV|rv0001|user011|R101|2026-03-20|13:00|14:00|2|CHECKED_IN|2026-03-20 09:00|2026/03/20 12:55|0\n",
                 "NOW|2026-03-20 09:00\n");
 
         String output = runCli(root, "");
         assertContains(output, "[파일 오류] reservations.txt 1행: checkedInAt 형식이 올바르지 않습니다.");
+    }
+
+    private static void testReservationRejectsCheckedInAtOutsideWindow() throws Exception {
+        Path root = createCliRoot();
+        writeData(root,
+                baseUsers(),
+                baseRooms(),
+                "RESV|rv0001|user011|R101|2026-03-20|13:00|14:00|2|CHECKED_IN|2026-03-20 09:00|2026-03-20 12:49|0\n",
+                "NOW|2026-03-20 09:00\n");
+
+        String output = runCli(root, "");
+        assertContains(output, "[파일 오류] reservations.txt 1행: checkedInAt은 체크인 가능 구간 안에 있어야 합니다.");
+    }
+
+    private static void testReservationRejectsExtensionCountOverLimit() throws Exception {
+        Path root = createCliRoot();
+        writeData(root,
+                baseUsers(),
+                baseRooms(),
+                "RESV|rv0001|user011|R101|2026-03-20|13:00|17:00|2|CHECKED_IN|2026-03-20 09:00|2026-03-20 12:55|4\n",
+                "NOW|2026-03-20 09:00\n");
+
+        String output = runCli(root, "");
+        assertContains(output, "[파일 오류] reservations.txt 1행: extensionCount는 3을 초과할 수 없습니다.");
     }
 
     private static void testPasswordRejectsEscapedNewlineStopsStartup() throws Exception {
@@ -746,7 +1388,7 @@ public class RegressionTest {
         writeData(root,
                 baseUsers(),
                 baseRooms(),
-                "RESV|rv0001|user999|R101|2026-03-20|13:00|14:00|2|RESERVED|2026-03-20 09:00|-\n",
+                "RESV|rv0001|user999|R101|2026-03-20|13:00|14:00|2|RESERVED|2026-03-20 09:00|-|0\n",
                 "NOW|2026-03-20 09:00\n");
 
         String output = runCli(root, "");
@@ -758,7 +1400,7 @@ public class RegressionTest {
         writeData(root,
                 baseUsers(),
                 baseRooms(),
-                "RESV|rv0001|user011|R999|2026-03-20|13:00|14:00|2|RESERVED|2026-03-20 09:00|-\n",
+                "RESV|rv0001|user011|R999|2026-03-20|13:00|14:00|2|RESERVED|2026-03-20 09:00|-|0\n",
                 "NOW|2026-03-20 09:00\n");
 
         String output = runCli(root, "");
@@ -770,7 +1412,7 @@ public class RegressionTest {
         writeData(root,
                 baseUsers(),
                 baseRooms(),
-                "RESV|rv0001|user011|R101|2026-03-20|13:00|14:00|2|CHECKED_IN|2026-03-20 09:00|-\n",
+                "RESV|rv0001|user011|R101|2026-03-20|13:00|14:00|2|CHECKED_IN|2026-03-20 09:00|-|0\n",
                 "NOW|2026-03-20 09:00\n");
 
         String output = runCli(root, "");
@@ -782,7 +1424,7 @@ public class RegressionTest {
         writeData(root,
                 baseUsers(),
                 baseRooms(),
-                "RESV|rv0001|user011|R101|2026-03-20|13:00|14:00|2|RESERVED|2026-03-20 09:00|2026-03-20 12:55\n",
+                "RESV|rv0001|user011|R101|2026-03-20|13:00|14:00|2|RESERVED|2026-03-20 09:00|2026-03-20 12:55|0\n",
                 "NOW|2026-03-20 09:00\n");
 
         String output = runCli(root, "");
@@ -794,7 +1436,7 @@ public class RegressionTest {
         writeData(root,
                 baseUsers(),
                 "ROOM|R101|A룸|4|OPEN\n",
-                "RESV|rv0001|user011|R101|2026-03-20|13:00|14:00|5|RESERVED|2026-03-20 09:00|-\n",
+                "RESV|rv0001|user011|R101|2026-03-20|13:00|14:00|5|RESERVED|2026-03-20 09:00|-|0\n",
                 "NOW|2026-03-20 09:00\n");
 
         String output = runCli(root, "");
@@ -806,8 +1448,8 @@ public class RegressionTest {
         writeData(root,
                 baseUsers(),
                 baseRooms(),
-                "RESV|rv0001|user011|R101|2026-03-20|13:00|15:00|2|RESERVED|2026-03-20 09:00|-\n"
-                        + "RESV|rv0002|user022|R101|2026-03-20|14:00|16:00|2|RESERVED|2026-03-20 09:10|-\n",
+                "RESV|rv0001|user011|R101|2026-03-20|13:00|15:00|2|RESERVED|2026-03-20 09:00|-|0\n"
+                        + "RESV|rv0002|user022|R101|2026-03-20|14:00|16:00|2|RESERVED|2026-03-20 09:10|-|0\n",
                 "NOW|2026-03-20 09:00\n");
 
         String output = runCli(root, "");
@@ -819,8 +1461,8 @@ public class RegressionTest {
         writeData(root,
                 baseUsers(),
                 baseRooms(),
-                "RESV|rv0001|user011|R101|2026-03-20|13:00|15:00|2|RESERVED|2026-03-20 09:00|-\n"
-                        + "RESV|rv0002|user011|R102|2026-03-20|14:00|16:00|2|RESERVED|2026-03-20 09:10|-\n",
+                "RESV|rv0001|user011|R101|2026-03-20|13:00|15:00|2|RESERVED|2026-03-20 09:00|-|0\n"
+                        + "RESV|rv0002|user011|R102|2026-03-20|14:00|16:00|2|RESERVED|2026-03-20 09:10|-|0\n",
                 "NOW|2026-03-20 09:00\n");
 
         String output = runCli(root, "");
@@ -1626,7 +2268,7 @@ public class RegressionTest {
                 "ROOM|R101|A룸|4|OPEN\n"
                         + "ROOM|R102|B룸|6|CLOSED\n"
                         + "ROOM|R103|C룸|2|OPEN\n",
-                "RESV|rv0001|user022|R101|2026-03-20|13:00|15:00|2|RESERVED|2026-03-20 09:00|-\n",
+                "RESV|rv0001|user022|R101|2026-03-20|13:00|15:00|2|RESERVED|2026-03-20 09:00|-|0\n",
                 "NOW|2026-03-20 09:00\n");
 
         String input = lines(
@@ -1654,7 +2296,7 @@ public class RegressionTest {
                 "ROOM|R101|A룸|4|OPEN\n"
                         + "ROOM|R102|B룸|6|OPEN\n"
                         + "ROOM|R103|C룸|8|OPEN\n",
-                "RESV|rv0001|user022|R101|2026-03-20|13:00|15:00|2|RESERVED|2026-03-20 09:00|-\n",
+                "RESV|rv0001|user022|R101|2026-03-20|13:00|15:00|2|RESERVED|2026-03-20 09:00|-|0\n",
                 "NOW|2026-03-20 09:00\n");
 
         String output = runCli(root, lines(
@@ -1814,7 +2456,7 @@ public class RegressionTest {
         writeData(root,
                 baseUsers(),
                 baseRooms(),
-                "RESV|rv0001|user011|R101|2026-03-20|13:00|15:00|2|RESERVED|2026-03-20 09:00|-\n",
+                "RESV|rv0001|user011|R101|2026-03-20|13:00|15:00|2|RESERVED|2026-03-20 09:00|-|0\n",
                 "NOW|2026-03-20 09:00\n");
 
         String input = lines(
@@ -1853,7 +2495,7 @@ public class RegressionTest {
 
         assertContains(output, "예약이 완료되었습니다.");
         assertContains(output, "예약번호: rv0001");
-        assertFileContains(root, "reservations.txt", "RESV|rv0001|user011|R102|2026-03-20|13:00|15:00|2|RESERVED|2026-03-20 09:00|-");
+        assertFileContains(root, "reservations.txt", "RESV|rv0001|user011|R102|2026-03-20|13:00|15:00|2|RESERVED|2026-03-20 09:00|-|0");
     }
 
     private static void testCreateReservationAllowsOneHourBoundary() throws Exception {
@@ -1874,7 +2516,7 @@ public class RegressionTest {
                 "0"));
 
         assertContains(output, "예약이 완료되었습니다.");
-        assertFileContains(root, "reservations.txt", "RESV|rv0001|user011|R102|2026-03-20|13:00|14:00|1|RESERVED|2026-03-20 09:00|-");
+        assertFileContains(root, "reservations.txt", "RESV|rv0001|user011|R102|2026-03-20|13:00|14:00|1|RESERVED|2026-03-20 09:00|-|0");
     }
 
     private static void testCreateReservationAllowsFourHourBoundary() throws Exception {
@@ -1896,7 +2538,7 @@ public class RegressionTest {
 
         assertContains(output, "예약이 완료되었습니다.");
         assertContains(output, "예약번호: rv0001");
-        assertFileContains(root, "reservations.txt", "RESV|rv0001|user011|R102|2026-03-20|13:00|17:00|2|RESERVED|2026-03-20 09:00|-");
+        assertFileContains(root, "reservations.txt", "RESV|rv0001|user011|R102|2026-03-20|13:00|17:00|2|RESERVED|2026-03-20 09:00|-|0");
     }
 
     private static void testCreateReservationRejectsInvalidDate() throws Exception {
@@ -2092,7 +2734,7 @@ public class RegressionTest {
         writeData(root,
                 baseUsers(),
                 baseRooms(),
-                "RESV|rv0001|user022|R101|2026-03-20|13:00|15:00|2|RESERVED|2026-03-20 09:00|-\n",
+                "RESV|rv0001|user022|R101|2026-03-20|13:00|15:00|2|RESERVED|2026-03-20 09:00|-|0\n",
                 "NOW|2026-03-20 09:00\n");
 
         String input = lines(
@@ -2117,7 +2759,7 @@ public class RegressionTest {
         writeData(root,
                 baseUsers(),
                 baseRooms(),
-                "RESV|rv0001|user011|R101|2026-03-20|13:00|15:00|2|RESERVED|2026-03-20 09:00|-\n",
+                "RESV|rv0001|user011|R101|2026-03-20|13:00|15:00|2|RESERVED|2026-03-20 09:00|-|0\n",
                 "NOW|2026-03-20 09:00\n");
 
         String input = lines(
@@ -2142,7 +2784,7 @@ public class RegressionTest {
         writeData(root,
                 baseUsers(),
                 baseRooms(),
-                "RESV|rv0001|user022|R101|2026-03-20|13:00|15:00|2|RESERVED|2026-03-20 09:00|-\n",
+                "RESV|rv0001|user022|R101|2026-03-20|13:00|15:00|2|RESERVED|2026-03-20 09:00|-|0\n",
                 "NOW|2026-03-20 09:00\n");
 
         String output = runCli(root, lines(
@@ -2159,7 +2801,7 @@ public class RegressionTest {
                 "0"));
 
         assertContains(output, "예약이 완료되었습니다.");
-        assertFileContains(root, "reservations.txt", "RESV|rv0002|user011|R101|2026-03-20|15:00|16:00|2|RESERVED|2026-03-20 09:00|-");
+        assertFileContains(root, "reservations.txt", "RESV|rv0002|user011|R101|2026-03-20|15:00|16:00|2|RESERVED|2026-03-20 09:00|-|0");
     }
 
     private static void testCreateReservationAllowsAdjacentUserWindow() throws Exception {
@@ -2167,7 +2809,7 @@ public class RegressionTest {
         writeData(root,
                 baseUsers(),
                 baseRooms(),
-                "RESV|rv0001|user011|R101|2026-03-20|13:00|15:00|2|RESERVED|2026-03-20 09:00|-\n",
+                "RESV|rv0001|user011|R101|2026-03-20|13:00|15:00|2|RESERVED|2026-03-20 09:00|-|0\n",
                 "NOW|2026-03-20 09:00\n");
 
         String output = runCli(root, lines(
@@ -2184,7 +2826,7 @@ public class RegressionTest {
                 "0"));
 
         assertContains(output, "예약이 완료되었습니다.");
-        assertFileContains(root, "reservations.txt", "RESV|rv0002|user011|R102|2026-03-20|15:00|16:00|2|RESERVED|2026-03-20 09:00|-");
+        assertFileContains(root, "reservations.txt", "RESV|rv0002|user011|R102|2026-03-20|15:00|16:00|2|RESERVED|2026-03-20 09:00|-|0");
     }
 
     private static void testCancelDeletesReservation() throws Exception {
@@ -2192,7 +2834,7 @@ public class RegressionTest {
         writeData(root,
                 baseUsers(),
                 baseRooms(),
-                "RESV|rv0001|user011|R101|2026-03-20|13:00|15:00|2|RESERVED|2026-03-20 09:00|-\n",
+                "RESV|rv0001|user011|R101|2026-03-20|13:00|15:00|2|RESERVED|2026-03-20 09:00|-|0\n",
                 "NOW|2026-03-20 09:00\n");
 
         String input = lines(
@@ -2214,7 +2856,7 @@ public class RegressionTest {
         writeData(root,
                 baseUsers(),
                 baseRooms(),
-                "RESV|rv0001|user022|R101|2026-03-20|13:00|15:00|2|RESERVED|2026-03-20 09:00|-\n",
+                "RESV|rv0001|user022|R101|2026-03-20|13:00|15:00|2|RESERVED|2026-03-20 09:00|-|0\n",
                 "NOW|2026-03-20 09:00\n");
 
         String output = runCli(root, lines(
@@ -2250,7 +2892,7 @@ public class RegressionTest {
         writeData(root,
                 baseUsers(),
                 baseRooms(),
-                "RESV|rv0001|user011|R101|2026-03-20|11:00|12:00|2|RESERVED|2026-03-20 09:00|-\n",
+                "RESV|rv0001|user011|R101|2026-03-20|11:00|12:00|2|RESERVED|2026-03-20 09:00|-|0\n",
                 "NOW|2026-03-20 11:00\n");
 
         String input = lines(
@@ -2283,9 +2925,9 @@ public class RegressionTest {
         writeData(sortedRoot,
                 baseUsers(),
                 baseRooms(),
-                "RESV|rv0003|user011|R103|2026-03-21|09:00|10:00|2|RESERVED|2026-03-20 09:00|-\n"
-                        + "RESV|rv0001|user011|R102|2026-03-20|13:00|14:00|2|RESERVED|2026-03-20 09:00|-\n"
-                        + "RESV|rv0002|user022|R101|2026-03-20|10:00|11:00|2|RESERVED|2026-03-20 09:00|-\n",
+                "RESV|rv0003|user011|R103|2026-03-21|09:00|10:00|2|RESERVED|2026-03-20 09:00|-|0\n"
+                        + "RESV|rv0001|user011|R102|2026-03-20|13:00|14:00|2|RESERVED|2026-03-20 09:00|-|0\n"
+                        + "RESV|rv0002|user022|R101|2026-03-20|10:00|11:00|2|RESERVED|2026-03-20 09:00|-|0\n",
                 "NOW|2026-03-20 09:00\n");
         String sortedOutput = runCli(sortedRoot, lines(
                 "2",
@@ -2306,7 +2948,7 @@ public class RegressionTest {
         writeData(root,
                 baseUsers(),
                 baseRooms(),
-                "RESV|rv0001|user011|R101|2026-03-20|11:00|12:00|2|RESERVED|2026-03-20 09:00|-\n",
+                "RESV|rv0001|user011|R101|2026-03-20|11:00|12:00|2|RESERVED|2026-03-20 09:00|-|0\n",
                 "NOW|2026-03-20 10:49\n");
 
         String input = lines(
@@ -2327,7 +2969,7 @@ public class RegressionTest {
         writeData(root,
                 baseUsers(),
                 baseRooms(),
-                "RESV|rv0001|user011|R101|2026-03-20|11:00|12:00|2|RESERVED|2026-03-20 09:00|-\n",
+                "RESV|rv0001|user011|R101|2026-03-20|11:00|12:00|2|RESERVED|2026-03-20 09:00|-|0\n",
                 "NOW|2026-03-20 10:50\n");
 
         String output = runCli(root, lines(
@@ -2340,7 +2982,7 @@ public class RegressionTest {
                 "0"));
 
         assertContains(output, "체크인이 완료되었습니다.");
-        assertFileContains(root, "reservations.txt", "RESV|rv0001|user011|R101|2026-03-20|11:00|12:00|2|CHECKED_IN|2026-03-20 09:00|2026-03-20 10:50");
+        assertFileContains(root, "reservations.txt", "RESV|rv0001|user011|R101|2026-03-20|11:00|12:00|2|CHECKED_IN|2026-03-20 09:00|2026-03-20 10:50|0");
     }
 
     private static void testCheckInBoundarySuccess() throws Exception {
@@ -2348,7 +2990,7 @@ public class RegressionTest {
         writeData(root,
                 baseUsers(),
                 baseRooms(),
-                "RESV|rv0001|user011|R101|2026-03-20|11:00|12:00|2|RESERVED|2026-03-20 09:00|-\n",
+                "RESV|rv0001|user011|R101|2026-03-20|11:00|12:00|2|RESERVED|2026-03-20 09:00|-|0\n",
                 "NOW|2026-03-20 11:10\n");
 
         String input = lines(
@@ -2362,7 +3004,7 @@ public class RegressionTest {
         String output = runCli(root, input);
 
         assertContains(output, "체크인이 완료되었습니다.");
-        assertFileContains(root, "reservations.txt", "RESV|rv0001|user011|R101|2026-03-20|11:00|12:00|2|CHECKED_IN|2026-03-20 09:00|2026-03-20 11:10");
+        assertFileContains(root, "reservations.txt", "RESV|rv0001|user011|R101|2026-03-20|11:00|12:00|2|CHECKED_IN|2026-03-20 09:00|2026-03-20 11:10|0");
     }
 
     private static void testCheckInAtStartTimeSuccess() throws Exception {
@@ -2370,7 +3012,7 @@ public class RegressionTest {
         writeData(root,
                 baseUsers(),
                 baseRooms(),
-                "RESV|rv0001|user011|R101|2026-03-20|11:00|12:00|2|RESERVED|2026-03-20 09:00|-\n",
+                "RESV|rv0001|user011|R101|2026-03-20|11:00|12:00|2|RESERVED|2026-03-20 09:00|-|0\n",
                 "NOW|2026-03-20 11:00\n");
 
         String output = runCli(root, lines(
@@ -2383,7 +3025,7 @@ public class RegressionTest {
                 "0"));
 
         assertContains(output, "체크인이 완료되었습니다.");
-        assertFileContains(root, "reservations.txt", "RESV|rv0001|user011|R101|2026-03-20|11:00|12:00|2|CHECKED_IN|2026-03-20 09:00|2026-03-20 11:00");
+        assertFileContains(root, "reservations.txt", "RESV|rv0001|user011|R101|2026-03-20|11:00|12:00|2|CHECKED_IN|2026-03-20 09:00|2026-03-20 11:00|0");
     }
 
     private static void testCheckInRejectsAlreadyCheckedInReservation() throws Exception {
@@ -2391,7 +3033,7 @@ public class RegressionTest {
         writeData(root,
                 baseUsers(),
                 baseRooms(),
-                "RESV|rv0001|user011|R101|2026-03-20|15:00|17:00|2|CHECKED_IN|2026-03-20 09:00|2026-03-20 14:55\n",
+                "RESV|rv0001|user011|R101|2026-03-20|15:00|17:00|2|CHECKED_IN|2026-03-20 09:00|2026-03-20 14:55|0\n",
                 "NOW|2026-03-20 15:00\n");
 
         String output = runCli(root, lines(
@@ -2404,7 +3046,7 @@ public class RegressionTest {
                 "0"));
 
         assertContains(output, "오류: 체크인 가능한 상태의 예약이 아닙니다.");
-        assertFileContains(root, "reservations.txt", "RESV|rv0001|user011|R101|2026-03-20|15:00|17:00|2|CHECKED_IN|2026-03-20 09:00|2026-03-20 14:55");
+        assertFileContains(root, "reservations.txt", "RESV|rv0001|user011|R101|2026-03-20|15:00|17:00|2|CHECKED_IN|2026-03-20 09:00|2026-03-20 14:55|0");
     }
 
     private static void testCheckInRejectsOtherUsersReservation() throws Exception {
@@ -2412,7 +3054,7 @@ public class RegressionTest {
         writeData(root,
                 baseUsers(),
                 baseRooms(),
-                "RESV|rv0001|user022|R101|2026-03-20|11:00|12:00|2|RESERVED|2026-03-20 09:00|-\n",
+                "RESV|rv0001|user022|R101|2026-03-20|11:00|12:00|2|RESERVED|2026-03-20 09:00|-|0\n",
                 "NOW|2026-03-20 10:55\n");
 
         String output = runCli(root, lines(
@@ -2448,7 +3090,7 @@ public class RegressionTest {
         writeData(root,
                 baseUsers(),
                 baseRooms(),
-                "RESV|rv0001|user011|R101|2026-03-20|11:00|12:00|2|RESERVED|2026-03-20 09:00|-\n",
+                "RESV|rv0001|user011|R101|2026-03-20|11:00|12:00|2|RESERVED|2026-03-20 09:00|-|0\n",
                 "NOW|2026-03-20 11:11\n");
 
         String output = runCli(root, lines(
@@ -2461,7 +3103,7 @@ public class RegressionTest {
                 "0"));
 
         assertContains(output, "오류: 체크인 가능한 상태의 예약이 아닙니다.");
-        assertFileContains(root, "reservations.txt", "RESV|rv0001|user011|R101|2026-03-20|11:00|12:00|2|NO_SHOW|2026-03-20 09:00|-");
+        assertFileContains(root, "reservations.txt", "RESV|rv0001|user011|R101|2026-03-20|11:00|12:00|2|NO_SHOW|2026-03-20 09:00|-|0");
     }
 
     private static void testCheckInClosedRoomRejected() throws Exception {
@@ -2470,7 +3112,7 @@ public class RegressionTest {
                 baseUsers(),
                 "ROOM|R101|A룸|4|CLOSED\n"
                         + "ROOM|R102|B룸|6|OPEN\n",
-                "RESV|rv0001|user011|R101|2026-03-20|11:00|12:00|2|RESERVED|2026-03-20 09:00|-\n",
+                "RESV|rv0001|user011|R101|2026-03-20|11:00|12:00|2|RESERVED|2026-03-20 09:00|-|0\n",
                 "NOW|2026-03-20 10:55\n");
 
         String input = lines(
@@ -2491,8 +3133,8 @@ public class RegressionTest {
         writeData(root,
                 baseUsers(),
                 baseRooms(),
-                "RESV|rv0001|user011|R101|2026-03-20|11:00|12:00|2|RESERVED|2026-03-20 09:00|-\n"
-                        + "RESV|rv0002|user022|R102|2026-03-20|09:00|10:00|2|CHECKED_IN|2026-03-20 08:30|2026-03-20 08:55\n",
+                "RESV|rv0001|user011|R101|2026-03-20|11:00|12:00|2|RESERVED|2026-03-20 09:00|-|0\n"
+                        + "RESV|rv0002|user022|R102|2026-03-20|09:00|10:00|2|CHECKED_IN|2026-03-20 08:30|2026-03-20 08:55|0\n",
                 "NOW|2026-03-20 09:00\n");
 
         String input = lines(
@@ -2511,8 +3153,8 @@ public class RegressionTest {
         assertContains(output, "현재 시각이 변경되었습니다.");
         assertContains(output, "RESERVED -> NO_SHOW : 1건");
         assertContains(output, "CHECKED_IN -> COMPLETED : 1건");
-        assertFileContains(root, "reservations.txt", "RESV|rv0001|user011|R101|2026-03-20|11:00|12:00|2|NO_SHOW|2026-03-20 09:00|-");
-        assertFileContains(root, "reservations.txt", "RESV|rv0002|user022|R102|2026-03-20|09:00|10:00|2|COMPLETED|2026-03-20 08:30|2026-03-20 08:55");
+        assertFileContains(root, "reservations.txt", "RESV|rv0001|user011|R101|2026-03-20|11:00|12:00|2|NO_SHOW|2026-03-20 09:00|-|0");
+        assertFileContains(root, "reservations.txt", "RESV|rv0002|user022|R102|2026-03-20|09:00|10:00|2|COMPLETED|2026-03-20 08:30|2026-03-20 08:55|0");
     }
 
     private static void testAllReservationsEmpty() throws Exception {
@@ -2536,8 +3178,8 @@ public class RegressionTest {
         writeData(root,
                 baseUsers(),
                 baseRooms(),
-                "RESV|rv0001|user011|R101|2026-03-21|11:00|12:00|2|RESERVED|2026-03-20 09:00|-\n"
-                        + "RESV|rv0002|user022|R102|2026-03-20|13:00|14:00|3|CHECKED_IN|2026-03-20 09:30|2026-03-20 12:55\n",
+                "RESV|rv0001|user011|R101|2026-03-21|11:00|12:00|2|RESERVED|2026-03-20 09:00|-|0\n"
+                        + "RESV|rv0002|user022|R102|2026-03-20|13:00|14:00|3|CHECKED_IN|2026-03-20 09:30|2026-03-20 12:55|0\n",
                 "NOW|2026-03-20 09:00\n");
 
         String output = runCli(root, lines(
@@ -2611,7 +3253,7 @@ public class RegressionTest {
         writeData(root,
                 baseUsers(),
                 baseRooms(),
-                "RESV|rv0001|user011|R101|2026-03-21|11:00|12:00|2|RESERVED|2026-03-20 09:00|-\n",
+                "RESV|rv0001|user011|R101|2026-03-21|11:00|12:00|2|RESERVED|2026-03-20 09:00|-|0\n",
                 "NOW|2026-03-20 09:00\n");
 
         String input = lines(
@@ -2632,7 +3274,7 @@ public class RegressionTest {
         assertContains(output, "변경 전 예약 레코드:");
         assertContains(output, "변경 후 예약 레코드:");
         assertContains(output, "예약 조정이 완료되었습니다.");
-        assertFileContains(root, "reservations.txt", "RESV|rv0001|user011|R102|2026-03-21|11:00|12:00|2|RESERVED|2026-03-20 09:00|-");
+        assertFileContains(root, "reservations.txt", "RESV|rv0001|user011|R102|2026-03-21|11:00|12:00|2|RESERVED|2026-03-20 09:00|-|0");
     }
 
     private static void testManualMoveRejectsClosedRoom() throws Exception {
@@ -2641,7 +3283,7 @@ public class RegressionTest {
                 baseUsers(),
                 "ROOM|R101|A룸|4|OPEN\n"
                         + "ROOM|R102|B룸|6|CLOSED\n",
-                "RESV|rv0001|user011|R101|2026-03-21|11:00|12:00|2|RESERVED|2026-03-20 09:00|-\n",
+                "RESV|rv0001|user011|R101|2026-03-21|11:00|12:00|2|RESERVED|2026-03-20 09:00|-|0\n",
                 "NOW|2026-03-20 09:00\n");
 
         String output = runCli(root, lines(
@@ -2663,7 +3305,7 @@ public class RegressionTest {
                 baseUsers(),
                 "ROOM|R101|A룸|6|OPEN\n"
                         + "ROOM|R102|B룸|1|OPEN\n",
-                "RESV|rv0001|user011|R101|2026-03-21|11:00|12:00|2|RESERVED|2026-03-20 09:00|-\n",
+                "RESV|rv0001|user011|R101|2026-03-21|11:00|12:00|2|RESERVED|2026-03-20 09:00|-|0\n",
                 "NOW|2026-03-20 09:00\n");
 
         String output = runCli(root, lines(
@@ -2684,8 +3326,8 @@ public class RegressionTest {
         writeData(root,
                 baseUsers(),
                 baseRooms(),
-                "RESV|rv0001|user011|R101|2026-03-21|11:00|12:00|2|RESERVED|2026-03-20 09:00|-\n"
-                        + "RESV|rv0002|user022|R102|2026-03-21|11:00|12:00|2|RESERVED|2026-03-20 09:30|-\n",
+                "RESV|rv0001|user011|R101|2026-03-21|11:00|12:00|2|RESERVED|2026-03-20 09:00|-|0\n"
+                        + "RESV|rv0002|user022|R102|2026-03-21|11:00|12:00|2|RESERVED|2026-03-20 09:30|-|0\n",
                 "NOW|2026-03-20 09:00\n");
 
         String output = runCli(root, lines(
@@ -2724,7 +3366,7 @@ public class RegressionTest {
                 baseUsers(),
                 "ROOM|R101|A룸|6|OPEN\n"
                         + "ROOM|R102|B룸|6|OPEN\n",
-                "RESV|rv0001|user011|R101|2026-03-19|11:00|12:00|6|COMPLETED|2026-03-18 09:00|2026-03-19 10:55\n",
+                "RESV|rv0001|user011|R101|2026-03-19|11:00|12:00|6|COMPLETED|2026-03-18 09:00|2026-03-19 10:55|0\n",
                 "NOW|2026-03-20 09:00\n");
 
         String output = runCli(root, lines(
@@ -2751,7 +3393,7 @@ public class RegressionTest {
                 baseUsers(),
                 "ROOM|R101|A룸|6|OPEN\n"
                         + "ROOM|R102|B룸|6|OPEN\n",
-                "RESV|rv0001|user011|R101|2026-03-20|09:00|10:00|5|RESERVED|2026-03-20 08:00|-\n",
+                "RESV|rv0001|user011|R101|2026-03-20|09:00|10:00|5|RESERVED|2026-03-20 08:00|-|0\n",
                 "NOW|2026-03-20 09:05\n");
 
         String output = runCli(root, lines(
@@ -2780,7 +3422,7 @@ public class RegressionTest {
                 baseUsers(),
                 "ROOM|R101|A룸|6|OPEN\n"
                         + "ROOM|R102|B룸|6|OPEN\n",
-                "RESV|rv0001|user011|R101|2026-03-20|09:00|10:00|5|CHECKED_IN|2026-03-20 08:00|2026-03-20 08:55\n",
+                "RESV|rv0001|user011|R101|2026-03-20|09:00|10:00|5|CHECKED_IN|2026-03-20 08:00|2026-03-20 08:55|0\n",
                 "NOW|2026-03-20 09:05\n");
 
         String output = runCli(root, lines(
@@ -2805,7 +3447,7 @@ public class RegressionTest {
                 baseUsers(),
                 "ROOM|R101|A룸|6|OPEN\n"
                         + "ROOM|R102|B룸|6|OPEN\n",
-                "RESV|rv0001|user011|R101|2026-03-21|11:00|12:00|6|RESERVED|2026-03-20 09:00|-\n",
+                "RESV|rv0001|user011|R101|2026-03-21|11:00|12:00|6|RESERVED|2026-03-20 09:00|-|0\n",
                 "NOW|2026-03-20 09:00\n");
 
         String output = runCli(root, lines(
@@ -2834,7 +3476,7 @@ public class RegressionTest {
         assertContains(output, "변경 후 ROOM 레코드:");
         assertContains(output, "룸 최대 수용 인원이 변경되었습니다.");
         assertFileContains(root, "rooms.txt", "ROOM|R101|A룸|4|OPEN");
-        assertFileContains(root, "reservations.txt", "RESV|rv0001|user011|R102|2026-03-21|11:00|12:00|6|RESERVED|2026-03-20 09:00|-");
+        assertFileContains(root, "reservations.txt", "RESV|rv0001|user011|R102|2026-03-21|11:00|12:00|6|RESERVED|2026-03-20 09:00|-|0");
     }
 
     private static void testCapacityChangeRollbackRestoresState() throws Exception {
@@ -2843,7 +3485,7 @@ public class RegressionTest {
                 baseUsers(),
                 "ROOM|R101|A룸|6|OPEN\n"
                         + "ROOM|R102|B룸|6|OPEN\n",
-                "RESV|rv0001|user011|R101|2026-03-21|11:00|12:00|6|RESERVED|2026-03-20 09:00|-\n",
+                "RESV|rv0001|user011|R101|2026-03-21|11:00|12:00|6|RESERVED|2026-03-20 09:00|-|0\n",
                 "NOW|2026-03-20 09:00\n");
 
         String output = runCli(root, lines(
@@ -2861,7 +3503,7 @@ public class RegressionTest {
 
         assertContains(output, "룸 컨디션 변경을 취소하여 원상복구했습니다.");
         assertFileContains(root, "rooms.txt", "ROOM|R101|A룸|6|OPEN");
-        assertFileContains(root, "reservations.txt", "RESV|rv0001|user011|R101|2026-03-21|11:00|12:00|6|RESERVED|2026-03-20 09:00|-");
+        assertFileContains(root, "reservations.txt", "RESV|rv0001|user011|R101|2026-03-21|11:00|12:00|6|RESERVED|2026-03-20 09:00|-|0");
     }
 
     private static void testCloseRoomWithCheckedInReservationRejected() throws Exception {
@@ -2869,7 +3511,7 @@ public class RegressionTest {
         writeData(root,
                 baseUsers(),
                 baseRooms(),
-                "RESV|rv0001|user011|R101|2026-03-20|09:00|10:00|2|CHECKED_IN|2026-03-20 08:00|2026-03-20 08:55\n",
+                "RESV|rv0001|user011|R101|2026-03-20|09:00|10:00|2|CHECKED_IN|2026-03-20 08:00|2026-03-20 08:55|0\n",
                 "NOW|2026-03-20 09:30\n");
 
         String output = runCli(root, lines(
@@ -2892,7 +3534,7 @@ public class RegressionTest {
         writeData(root,
                 baseUsers(),
                 baseRooms(),
-                "RESV|rv0001|user011|R101|2026-03-20|09:00|10:00|2|RESERVED|2026-03-20 08:00|-\n",
+                "RESV|rv0001|user011|R101|2026-03-20|09:00|10:00|2|RESERVED|2026-03-20 08:00|-|0\n",
                 "NOW|2026-03-20 09:05\n");
 
         String output = runCli(root, lines(
@@ -2918,7 +3560,7 @@ public class RegressionTest {
         writeData(root,
                 baseUsers(),
                 baseRooms(),
-                "RESV|rv0001|user011|R101|2026-03-21|11:00|12:00|2|RESERVED|2026-03-20 09:00|-\n",
+                "RESV|rv0001|user011|R101|2026-03-21|11:00|12:00|2|RESERVED|2026-03-20 09:00|-|0\n",
                 "NOW|2026-03-20 09:00\n");
 
         String output = runCli(root, lines(
@@ -2972,7 +3614,7 @@ public class RegressionTest {
         writeData(root,
                 baseUsers(),
                 baseRooms(),
-                "RESV|rv0001|user011|R101|0000-01-01|13:00|14:00|2|RESERVED|2026-03-20 09:00|-\n",
+                "RESV|rv0001|user011|R101|0000-01-01|13:00|14:00|2|RESERVED|2026-03-20 09:00|-|0\n",
                 "NOW|2026-03-20 09:00\n");
 
         String output = runCli(root, "");
@@ -2984,7 +3626,7 @@ public class RegressionTest {
         writeData(root,
                 baseUsers(),
                 baseRooms(),
-                "RESV|rv0001|user011|R101|-0001-01-01|13:00|14:00|2|RESERVED|2026-03-20 09:00|-\n",
+                "RESV|rv0001|user011|R101|-0001-01-01|13:00|14:00|2|RESERVED|2026-03-20 09:00|-|0\n",
                 "NOW|2026-03-20 09:00\n");
 
         String output = runCli(root, "");


### PR DESCRIPTION
## Summary
- Add RESV extensionCount persistence and strict 12-field validation
- Add user/reservation ID upper-bound handling
- Add no-show penalty, excellent member calculation, and reservation extension flow
- Update regression coverage for final second-round rules

## Verification
- cmd /c gradlew.bat check --no-daemon