### PR TITLE
[codex] Align extension flow with final spec

### DIFF
--- a/src/main/java/ku/com/CliApp.java
+++ b/src/main/java/ku/com/CliApp.java
@@ -477,12 +477,6 @@ final class CliApp {
             return;
         }
 
-        if (standing.underPenalty(data.currentTime)) {
-            System.out.println("오류: 노쇼 패널티로 "
-                    + TimeFormats.formatDateTime(standing.penaltyUntil)
-                    + " 이후 예약 연장이 가능합니다.");
-            return;
-        }
         if (reservation.status != ReservationStatus.CHECKED_IN) {
             System.out.println("오류: CHECKED_IN 상태의 예약만 연장할 수 있습니다.");
             return;
@@ -532,7 +526,10 @@ final class CliApp {
         reservation.endTime = newEnd.toLocalTime();
         reservation.extensionCount++;
         store.saveAll(data);
-        printRecordChange("RESV", beforeRecord, reservation.toRecord());
+        System.out.println("기존 예약 레코드:");
+        System.out.println(beforeRecord);
+        System.out.println("변경 후 예약 레코드:");
+        System.out.println(reservation.toRecord());
         System.out.println("예약 시간이 1시간 연장되었습니다.");
     }
 

--- a/src/test/java/ku/com/RegressionTest.java
+++ b/src/test/java/ku/com/RegressionTest.java
@@ -496,6 +496,12 @@ public class RegressionTest {
                 "0"));
 
         assertContains(output, "회원 상태: 우수회원");
+        assertContains(output, "기존 예약 레코드:");
+        assertContains(output,
+                "RESV|rv0003|user011|R101|2026-03-20|13:00|15:00|2|CHECKED_IN|2026-03-20 09:00|2026-03-20 12:55|0");
+        assertContains(output, "변경 후 예약 레코드:");
+        assertContains(output,
+                "RESV|rv0003|user011|R101|2026-03-20|13:00|16:00|2|CHECKED_IN|2026-03-20 09:00|2026-03-20 12:55|1");
         assertContains(output, "예약 시간이 1시간 연장되었습니다.");
         assertFileContains(root, "reservations.txt",
                 "RESV|rv0003|user011|R101|2026-03-20|13:00|16:00|2|CHECKED_IN|2026-03-20 09:00|2026-03-20 12:55|1");


### PR DESCRIPTION
## What changed
- Removed the unreachable post-lookup `underPenalty()` branch from reservation extension.
- Updated successful extension output to use the final-spec labels `기존 예약 레코드:` and `변경 후 예약 레코드:`.
- Added regression assertions for the reservation extension before/after records and labels.

## Why
The final design document defines reservation extension as an excellent-member precheck followed by reservation lookup, owner check, and `CHECKED_IN` validation. It also requires reservation-specific success labels instead of the generic `RESV` change labels.

## Validation
- `./gradlew test`